### PR TITLE
Lateral joins and relational calculus.

### DIFF
--- a/AbstractRelation.v
+++ b/AbstractRelation.v
@@ -10,6 +10,7 @@ Module Type REL.
   Parameter inter : forall n, R n -> R n -> R n.
   Parameter times : forall m n, R m -> R n -> R (m + n).
   Parameter sum   : forall m n, R m -> (T m -> T n) -> R n.
+  Parameter rsum  : forall m n, R m -> (T m -> R n) -> R n.
   Parameter sel   : forall n, R n -> (T n -> bool) -> R n.
   Parameter flat  : forall n, R n -> R n.
   Parameter supp  : forall n, R n -> list (T n).
@@ -20,6 +21,7 @@ Module Type REL.
   Implicit Arguments inter [n].
   Implicit Arguments times [m n].
   Implicit Arguments sum [m n].
+  Implicit Arguments rsum [m n].
   Implicit Arguments sel [n].
   Implicit Arguments flat [n].
   Implicit Arguments supp [n].
@@ -27,8 +29,13 @@ Module Type REL.
   Definition card := fun n S => memb (@sum n 0 S (fun _ => Vector.nil _)) (Vector.nil _).
   Implicit Arguments card [n].
 
-  Parameter Rnil : R 0.
+  Parameter Rnil : forall n, R n.
   Parameter Rone : R 0.
+  Parameter Rsingle : forall n, T n -> R n.
+
+  Implicit Arguments Rnil [n].
+  Implicit Arguments Rsingle [n].
+
   (* generalized cartesian product of m relations, each taken with its arity n *)
   Fixpoint prod (Rl : list { n : nat & R n }) 
     : R (list_sum (List.map (projT1 (P := fun n => R n)) Rl)) :=
@@ -46,16 +53,8 @@ Module Type REL.
   Hypothesis V_dec : forall (v w : V), {v = w} + {v <> w}.
   Hypothesis V_eqb_eq : forall (v w : V), V_eqb v w = true <-> v = w.
   Parameter T_dec : forall n, forall (x y : T n), {x = y} + {x <> y}.
-(*
-  Proof.
-    intros. eapply Vector.eq_dec. apply V_eqb_eq.
-  Qed.
-*)
+
   Parameter T_eqb_eq : forall n, forall (v w : T n), T_eqb v w = true <-> v = w.
-(*  Proof.
-    intros. eapply Vector.eqb_eq. apply V_eqb_eq.
-  Qed.
-*)
 
   Parameter p_fs : forall n, forall r : R n, forall t, memb r t > 0 -> List.In t (supp r).
   Parameter p_fs_r : forall n, forall r : R n, forall t, List.In t (supp r) -> memb r t > 0.
@@ -67,11 +66,15 @@ Module Type REL.
                       t = Vector.append t1 t2 -> memb (times r1 r2) t = memb r1 t1 * memb r2 t2.
   Parameter p_sum : forall m n, forall r : R m, forall f : T m -> T n, forall t, 
                     memb (sum r f) t = list_sum (List.map (memb r) (filter (fun x => T_eqb (f x) t) (supp r))).
+  Parameter p_rsum : forall m n, forall r : R m, forall f : T m -> R n, forall t,
+                    memb (rsum r f) t = list_sum (List.map (fun t0 => memb r t0 * memb (f t0) t) (supp r)).
   Parameter p_self : forall n, forall r : R n, forall p t, p t = false -> memb (sel r p) t = 0.
   Parameter p_selt : forall n, forall r : R n, forall p t, p t = true -> memb (sel r p) t = memb r t.
   Parameter p_flat : forall n, forall r : R n, forall t, memb (flat r) t = flatnat (memb r t).
-  Parameter p_nil : forall r, memb Rnil r = 0.
-  Parameter p_one : forall r, memb Rone r = 1.
+  Parameter p_nil : forall n (t : T n), memb Rnil t = 0.
+  Parameter p_one : forall t, memb Rone t = 1.
+  Parameter p_single : forall n (t : T n), memb (Rsingle t) t = 1.
+  Parameter p_single_neq : forall n (t1 t2 : T n), t1 <> t2 -> memb (Rsingle t1) t2 = 0.
 
   Parameter p_ext : forall n, forall r s : R n, (forall t, memb r t = memb s t) -> r = s.
 

--- a/Common.v
+++ b/Common.v
@@ -61,24 +61,24 @@ Proof.
 Qed.
 
 
-Module Type DB.
-  Parameter Name : Type.
-  Hypothesis Name_dec : forall x y:Name, {x = y} + {x <> y}. 
+Module Db.
+  Axiom Name : Type.
+  Axiom Name_dec : forall x y:Name, {x = y} + {x <> y}. 
   Definition FullName := (Name * Name)%type.
   Definition FullVar  := (nat * Name)%type.
   Definition Scm      := list Name.         (* schema (attribute names for a relation) *)
   Definition Ctx      := list Scm.          (* context (domain of an environment) = list of lists of names *)
 
-  Parameter BaseConst : Type.
+  Axiom BaseConst : Type.
   Definition Value    := option BaseConst.
   Definition null     : Value := None.
   Definition c_sem     : BaseConst -> Value := Some.    (* semantics of constants *)
 
   Declare Module Rel  : REL with Definition V := Value.
 
-  Parameter D         : Type.
-  Variable db_schema  : D -> Name -> option (list Name).
-  Hypothesis db_rel   : forall d n xl, db_schema d n = Some xl -> Rel.R (List.length xl).
+  Axiom D          : Type.
+  Axiom db_schema  : D -> Name -> option (list Name).
+  Axiom db_rel   : forall d n xl, db_schema d n = Some xl -> Rel.R (List.length xl).
   Implicit Arguments db_rel [d n xl].
 
   Lemma Scm_dec (s1 s2 : Scm) : {s1 = s2} + {s1 <> s2}.
@@ -107,9 +107,9 @@ Module Type DB.
   Definition FullName_eq : FullName -> FullName -> bool :=
     fun A B => match FullName_dec A B with left _ => true | right _ => false end.
 
-  Parameter c_eq : BaseConst -> BaseConst -> bool.
-  Hypothesis BaseConst_dec : forall (c1 c2 : BaseConst), { c1 = c2 } + { c1 <> c2 }.
-  Hypothesis BaseConst_eqb_eq : forall (c1 c2 : BaseConst), c_eq c1 c2 = true <-> c1 = c2.
+  Axiom c_eq : BaseConst -> BaseConst -> bool.
+  Axiom BaseConst_dec : forall (c1 c2 : BaseConst), { c1 = c2 } + { c1 <> c2 }.
+  Axiom BaseConst_eqb_eq : forall (c1 c2 : BaseConst), c_eq c1 c2 = true <-> c1 = c2.
 
-End DB.
+End Db.
 

--- a/Common.v
+++ b/Common.v
@@ -81,6 +81,8 @@ Module Db.
   Axiom db_rel   : forall d n xl, db_schema d n = Some xl -> Rel.R (List.length xl).
   Implicit Arguments db_rel [d n xl].
 
+  Axiom db_schema_nodup : forall d n xl, db_schema d n = Some xl -> List.NoDup xl.
+
   Lemma Scm_dec (s1 s2 : Scm) : {s1 = s2} + {s1 <> s2}.
     exact (list_eq_dec Name_dec s1 s2).
   Qed.

--- a/Common.v
+++ b/Common.v
@@ -1,0 +1,115 @@
+Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat AbstractRelation Omega.
+
+
+Fixpoint findpos {A} (l : list A) (p : A -> bool) start {struct l} : option nat := 
+  match l with
+  | List.nil => None
+  | List.cons a l0 => if p a then Some start else findpos l0 p (S start)
+  end.
+
+Definition ret {A} : A -> option A := Some.
+Definition bind {A B} : option A -> (A -> option B) -> option B :=
+  fun a f => match a with None => None | Some x => f x end.
+Definition monadic_map {A B} (f : A -> option B) (l : list A) : option (list B) :=
+  List.fold_right (fun a mbl => 
+    bind mbl (fun bl => 
+    bind (f a) (fun b => 
+    ret (b::bl))))
+  (ret List.nil) l.
+
+Lemma length_monadic_map (A B: Type) (f : A -> option B) (l1 : list A) :
+  forall l2, monadic_map f l1 = Some l2 -> List.length l1 = List.length l2.
+elim l1.
++ intro. simpl. unfold ret. intro. injection H. intro. subst. auto.
++ simpl. intros a l. case (monadic_map f l).
+  - simpl. case (f a).
+    * simpl. unfold ret. intros b l0 IH l2 Hl2. injection Hl2. intro H.
+      subst. simpl. apply f_equal. apply IH. reflexivity.
+    * simpl. intros. discriminate.
+  - simpl. intros. discriminate.
+Qed.
+
+Lemma bind_elim (A B : Type) (x : option A) (f : A -> option B) (P : option B -> Prop) :
+  (forall y, x = Some y -> P (f y)) -> (x = None -> P None) ->
+  P (bind x f).
+intros. destruct x eqn:e; simpl; auto.
+Qed.
+
+Lemma length_to_list (A : Type) (n : nat) (v : Vector.t A n) : length (to_list v) = n.
+elim v. auto.
+intros. transitivity (S (length (to_list t ))); auto.
+Qed.
+
+Definition vec_monadic_map {A B n} (f : A -> option B) (v : Vector.t A n) : option (Vector.t B n).
+Proof.
+  destruct (monadic_map f (Vector.to_list v)) eqn:e.
+  + refine (Some (cast (of_list l) _)).
+    refine (let Hlen := length_monadic_map _ _ _ _ _ e in _).
+    rewrite <- Hlen.
+    apply length_to_list.
+  + apply None.
+Qed.
+
+Lemma findpos_Some A (s : list A) p :
+  forall m n, findpos s p m = Some n -> n < m + length s.
+Proof.
+  elim s; simpl; intros; intuition.
+  + discriminate H.
+  + destruct (p a); intuition.
+    - injection H0. omega. 
+    - pose (H _ _ H0). omega.
+Qed.
+
+
+Module Type DB.
+  Parameter Name : Type.
+  Hypothesis Name_dec : forall x y:Name, {x = y} + {x <> y}. 
+  Definition FullName := (Name * Name)%type.
+  Definition FullVar  := (nat * Name)%type.
+  Definition Scm      := list Name.         (* schema (attribute names for a relation) *)
+  Definition Ctx      := list Scm.          (* context (domain of an environment) = list of lists of names *)
+
+  Parameter BaseConst : Type.
+  Definition Value    := option BaseConst.
+  Definition null     : Value := None.
+  Definition c_sem     : BaseConst -> Value := Some.    (* semantics of constants *)
+
+  Declare Module Rel  : REL with Definition V := Value.
+
+  Parameter D         : Type.
+  Variable db_schema  : D -> Name -> option (list Name).
+  Hypothesis db_rel   : forall d n xl, db_schema d n = Some xl -> Rel.R (List.length xl).
+  Implicit Arguments db_rel [d n xl].
+
+  Lemma Scm_dec (s1 s2 : Scm) : {s1 = s2} + {s1 <> s2}.
+    exact (list_eq_dec Name_dec s1 s2).
+  Qed.
+
+  Definition Scm_eq : Scm -> Scm -> bool := 
+    fun s1 s2 => match Scm_dec s1 s2 with left _ => true | right _ => false end.
+
+  Lemma Scm_eq_elim (P : bool -> Prop) (s s' : Scm) (Htrue : s = s' -> P true) (Hfalse : s <> s' -> P false)
+  : P (Scm_eq s s').
+  unfold Scm_eq. destruct (Scm_dec s s') eqn:e. all: auto.
+  Qed.
+
+
+  Lemma FullName_dec (A B : FullName) : {A = B} + {A <> B}.
+    elim A; intros A1 A2.
+    elim B; intros B1 B2.
+    elim (Name_dec A1 B1); intro H1.
+    + elim (Name_dec A2 B2); intro H2.
+      - subst. left. reflexivity.
+      - right. intro. injection H. intro. contradiction H2.
+    + right. intro. injection H. intros _ H2. contradiction H1.
+  Qed.
+
+  Definition FullName_eq : FullName -> FullName -> bool :=
+    fun A B => match FullName_dec A B with left _ => true | right _ => false end.
+
+  Parameter c_eq : BaseConst -> BaseConst -> bool.
+  Hypothesis BaseConst_dec : forall (c1 c2 : BaseConst), { c1 = c2 } + { c1 <> c2 }.
+  Hypothesis BaseConst_eqb_eq : forall (c1 c2 : BaseConst), c_eq c1 c2 = true <-> c1 = c2.
+
+End DB.
+

--- a/Eval.v
+++ b/Eval.v
@@ -1,0 +1,540 @@
+Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Syntax AbstractRelation Bool.Sumbool Tribool JMeq 
+  FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Util RelFacts Common.
+
+Module Type EV (Db : DB).
+  Import Db.
+
+  Parameter preenv : Type.  (* environment (for evaluation) *)
+  Parameter env : Ctx -> Type.
+  Parameter env_lookup  : forall G : Ctx, env G -> FullVar -> option Value.
+
+  Hypothesis env_of_tuple : forall G, forall Vl : Db.Rel.T (list_sum (List.map (List.length (A:=Name)) G)), env G.
+
+  Hypothesis env_app : forall G1 G2, env G1 -> env G2 -> env (G1++G2).
+
+  Hypothesis subenv1 : forall G1 G2, env (G1++G2) -> env G1.
+
+  Parameter tuple_of_env : forall G, env G -> Db.Rel.T (list_sum (List.map (List.length (A:=Name)) G)).
+
+End EV.
+
+Module Evl (Db : DB) <: EV Db.
+  Import Db.
+
+  Definition preenv := list Value. (* environment (for evaluation) *)
+  Definition env := fun (g : Ctx) => 
+    { h : preenv & (List.length (List.concat g) =? List.length h) = true }. 
+
+  Fixpoint scm_env s (h : preenv) {struct s} : list (Name * Value) * preenv := 
+    match s, h with
+    | List.nil, _ => (List.nil, h)
+    | _, List.nil => (List.nil, List.nil)
+    | a::s0, v::h0 => let (sh,h') := scm_env s0 h0 in ((a,v)::sh,h')
+    end. 
+
+  Fixpoint ctx_env G (h : preenv) {struct G} : list (list (Name * Value)) :=
+    match G with
+    | List.nil => List.nil
+    | s::G0 => let (sh,h') := scm_env s h in sh :: ctx_env G0 h'
+    end.
+
+  Definition env_lookup : forall G : Ctx, env G -> FullVar -> option Value :=
+    fun G h x => let (n,a) := x in
+      bind (nth_error (ctx_env G (projT1 h)) n)
+        (fun sh => bind (find (fun x => if Db.Name_dec (fst x) a then true else false) sh)
+          (fun p => ret (snd p))).
+
+  Lemma j_var_nth_aux (h : list Value) s a : forall i,
+    findpos s (fun x => if Db.Name_dec x a then true else false) 0 = Some i ->
+    length s = length h ->
+    { v : Value & nth_error h i = Some v }.
+  Proof.
+    intros. cut (nth_error h i <> None).
+    + destruct (nth_error h i); intuition. exists v; reflexivity.
+    + apply nth_error_Some. rewrite <- H0. pose (findpos_Some _ _ _ _ _ H). omega.
+  Qed.
+
+  Lemma nth_error_map A B n a (f : A -> B) : 
+    forall (l : list A), nth_error l n = Some a ->
+    nth_error (List.map f l) n = Some (f a).
+  Proof.
+    elim n; simpl.
+    + intro l; destruct l; simpl; intuition.
+      - discriminate H.
+      - injection H. intro. rewrite H0. reflexivity.
+    + intros m IH l; destruct l; simpl; intuition. discriminate H.
+  Qed.
+
+  Lemma nth_error_map_r A B n b (f : A -> B) : 
+    forall (l : list A), nth_error (List.map f l) n = Some b ->
+    { a : A & nth_error l n = Some a /\ b = f a }.
+  Proof.
+    elim n; simpl.
+    + intro l; destruct l; simpl; intuition.
+      - discriminate H.
+      - injection H. intro. exists a. rewrite H0. auto.
+    + intros m IH l; destruct l; simpl; intuition. discriminate H.
+  Qed.
+
+(*
+  Lemma env_scm_length (G : Ctx) (h : env G) : forall n s, 
+    List.nth_error G n = Some s -> { h0 : list Value & List.nth_error (projT1 h) n = Some h0 /\ length s = length h0 }.
+  Proof.
+    intros. destruct h. pose (nth_error_map _ _ _ _ (@length Name) _ H).
+    clearbody e0. rewrite e in e0. destruct (nth_error_map_r _ _ _ _ _ _ e0).
+    destruct a. exists x0. simpl. auto.
+  Qed.
+
+  Definition unopt {A} : forall (x : option A), x <> None -> A.
+    refine (fun x => match x as x0 return (x0 <> None -> A) with Some x' => fun _ => x' | None => _ end).
+    intro Hfalse. contradiction Hfalse. reflexivity.
+  Defined.
+*)
+
+  Lemma unopt_pi {A} (x : option A) Hx Hx' : unopt x Hx = unopt x Hx'.
+  Proof.
+    destruct x; intuition.
+    contradiction Hx. reflexivity.
+  Qed.
+
+  Lemma p_scm_preenv s G (h : preenv) :
+    length h = length (List.concat (s::G)) ->
+    forall y h0, scm_env s h = (y,h0) ->
+    length y = length s /\ length h0 = length h - length s.
+  Proof.
+    intros. generalize s, H, y, h0, H0. clear s H y h0 H0. induction h; simpl; intros.
+    + destruct s.
+      - simpl in H0. injection H0. intros. subst. intuition.
+      - simpl in H. discriminate H.
+    + destruct s.
+      - simpl. simpl in H0. injection H0; intros; subst. simpl; intuition.
+      - simpl in H0. destruct (scm_env s h) eqn:e0. injection H0; intros; clear H0. 
+        simpl in H. injection H. intro. clear H.
+        destruct (IHh _ H0 _ _ e0). subst. split.
+        * simpl. rewrite H. reflexivity.
+        * rewrite H3. simpl. reflexivity.
+  Qed.
+
+  Lemma p_scm_env s G (h : env (s::G)) :
+    forall y p, scm_env s (projT1 h) = (y,p) ->
+    length y = length s /\ length p = length (projT1 h) - length s.
+  Proof.
+    intros. destruct h. simpl in e. eapply (p_scm_preenv _ G). symmetry.
+    apply Nat.eqb_eq. exact e. exact H.
+  Qed.
+
+  Definition env_hd {a} {s} {G} : env ((a::s)::G) -> Value.
+    refine (fun h => unopt (List.hd_error (projT1 h)) _).
+    destruct h. simpl. destruct x; simpl; intuition. discriminate H.
+  Defined.
+
+  Definition env_tl {a} {s} {G} : env ((a::s)::G) -> env (s::G).
+    refine (fun h => _).
+    enough ((length (concat (s::G)) =? length (List.tl (projT1 h))) = true).
+    unfold env. econstructor. exact H.
+    destruct h. destruct x; simpl; intuition.
+  Defined.
+
+  Fixpoint env_skip {s} {G} {s0} : env ((s0++s)::G) -> env (s::G).
+   refine (match s0 with List.nil => _ | a0::s1 => _ end).
+   + refine (fun h => h).
+   + refine (fun h => env_skip _ _ _ (env_tl h)).
+  Defined.
+
+  Inductive j_var_sem : forall s, Name -> (env (s::List.nil) -> Value) -> Prop :=
+  | jvs_hd : forall a s, ~ List.In a s -> j_var_sem (a::s) a (fun h => env_hd h)
+  | jvs_tl : forall a s b, 
+      forall Sb, a <> b -> j_var_sem s b Sb -> j_var_sem (a::s) b (fun h => Sb (env_tl h)).
+
+  Theorem j_var_sem_fun :
+    forall s a Sa, j_var_sem s a Sa -> forall Sa0, j_var_sem s a Sa0 -> Sa = Sa0.
+  Proof.
+    intros s a Sa Ha. induction Ha.
+    + intros. inversion H0.
+      - apply (existT_eq_elim H5). intros _. apply JMeq_eq.
+      - contradiction H5. reflexivity.
+    + intros. inversion H0.
+      - contradiction H.
+      - apply (existT_eq_elim H3); clear H3; intros; subst.
+        rewrite (IHHa _ H6). reflexivity.
+  Qed.
+
+  Definition subenv1 {G1} {G2} : env (G1++G2) -> env G1.
+    refine (fun h => _).
+    enough ((length (concat G1) =? length (firstn (length (concat G1)) (projT1 h))) = true).
+    unfold env. econstructor. exact H.
+    destruct h. apply Nat.eqb_eq. symmetry. apply firstn_length_le.
+    simpl. rewrite <- (proj1 (Nat.eqb_eq _ _) e). rewrite concat_app. rewrite app_length. omega.
+  Defined.
+
+  Definition subenv2 {G1} {G2} : env (G1++G2) -> env G2.
+    refine (fun h => _).
+    enough ((length (concat G2) =? length (skipn (length (concat G1)) (projT1 h))) = true).
+    unfold env. econstructor. exact H.
+    destruct h. apply Nat.eqb_eq. simpl. rewrite length_skipn.
+    rewrite <- (proj1 (Nat.eqb_eq _ _) e). rewrite concat_app. rewrite app_length. omega.
+  Defined.
+
+  Definition env_app : forall G1 G2, env G1 -> env G2 -> env (G1++G2).
+    refine (fun G1 G2 h1 h2 => existT _ (projT1 h1 ++ projT1 h2) _).
+    destruct h1. destruct h2. apply Nat.eqb_eq. 
+    rewrite concat_app. simpl. do 2 rewrite app_length. 
+    f_equal; apply Nat.eqb_eq.
+    exact e.
+    exact e0.
+  Defined.
+
+  Fixpoint env_of_tuple G : Db.Rel.T (list_sum (List.map (List.length (A:=Name)) G)) -> env G.
+    refine 
+      ((match G as G0 return (G = G0 -> Db.Rel.T (list_sum (List.map (@length Name) G0)) -> env G0) with
+      | List.nil => _
+      | List.cons s G1 => _
+      end) eq_refl).
+    + refine (fun _ _ => existT _ List.nil _). reflexivity.
+    + simpl. intros. pose (p := split X); clearbody p.
+      apply (env_app (s :: List.nil)).
+      - eapply (existT _ (Vector.to_list (fst p)) _). Unshelve. simpl.
+        rewrite length_to_list. rewrite app_length. simpl. apply Nat.eqb_eq. omega.
+      - apply (env_of_tuple _ (snd p)).
+  Defined.
+
+  Definition tuple_of_env G : env G -> Db.Rel.T (list_sum (List.map (List.length (A:=Name)) G)).
+    refine (fun h => cast _ _ _ (of_list (projT1 h))).
+    unfold Rel.T. f_equal. rewrite <- length_concat_list_sum. symmetry.
+    destruct h; simpl. destruct (Nat.eqb_eq (length (concat G)) (length x)). auto.
+  Defined.
+
+  Lemma of_list_to_list_opp A n (v : Vector.t A n) :
+    of_list (to_list v) ~= v.
+  Proof.
+    induction v; simpl; intuition.
+    apply Vector_cons_equal. change (length (to_list v) ~= n). apply eq_JMeq; apply length_to_list.
+    reflexivity.
+    apply IHv.
+  Qed.
+
+  Lemma tl_of_list_to_list A n (v : Vector.t A (S n)) :
+    tl v ~= of_list (List.tl (to_list v)).
+  Proof.
+    eapply (caseS (fun _ v0 => tl v0 ~= of_list (List.tl (to_list v0))) _ v). Unshelve.
+    simpl; intros. change (t ~= of_list (to_list t)). rewrite of_list_to_list_opp. reflexivity.
+  Qed.
+
+  Lemma env_skip_skip s1 s2 s3 G (h1 : env (((s1 ++ s2) ++ s3)::G)) (h2 : env ((s1 ++ (s2 ++ s3))::G)) :
+    h1 ~= h2 -> env_skip h1 ~= env_skip (env_skip h2).
+  Proof.
+    intro. induction s1.
+    + rewrite H. reflexivity.
+    + apply IHs1.
+      eapply (f_JMequal (@env_tl a ((s1++s2)++s3) _) (@env_tl a (s1++(s2++s3)) _) h1 h2); intuition.
+      rewrite app_assoc. reflexivity.
+      Unshelve.
+      rewrite app_assoc. reflexivity.
+      rewrite app_assoc. reflexivity.
+  Qed.
+
+  Lemma env_skip_single a s G (h : env (((a::List.nil)++s)::G)) :
+    env_skip h ~= env_tl h.
+  Proof.
+    reflexivity.
+  Qed.
+
+  Lemma tl_tuple_of_env a s G (h : env ((a::s)::G)) : 
+    Vector.tl (tuple_of_env _ h) = tuple_of_env _ (env_tl h).
+  Proof.
+    destruct h. unfold tuple_of_env. simpl.
+    apply JMeq_eq. symmetry. apply cast_JMeq.
+    rewrite tl_of_list_to_list. apply (f_JMeq _ _ (@of_list _) _ _).
+    f_equal. transitivity (to_list (of_list x)). symmetry; apply to_list_of_list_opp.
+    apply to_list_eq. rewrite <- (proj1 (Nat.eqb_eq _ _) e).
+    simpl. rewrite app_length. f_equal.
+    change (length s + length (concat G) = length s + list_sum (List.map (@length _) G)).
+    f_equal. apply length_concat_list_sum.
+    symmetry. apply cast_JMeq. reflexivity.
+  Qed.
+
+  Definition Vector_combine {A} {B} {n} : Vector.t A n -> Vector.t B n -> Vector.t (A * B) n :=
+    Vector.rect2 (fun n0 _ _ => Vector.t (A*B) n0) (Vector.nil _)
+    (fun m _ _ acc a b => Vector.cons _ (a,b) _ acc).
+
+  Lemma length_tolist A n (v : Vector.t A n): length (to_list v) = n.
+  Proof.
+    elim v; simpl; intuition.
+  Qed.
+
+  Lemma nth_error_app2_eq {A} (G2:list A) n : forall G1, nth_error (G2 ++ G1) (length G2 + n) = nth_error G1 n.
+  Proof.
+    elim G2; auto.
+  Qed.
+
+  Lemma scm_env_skipn s : forall l h h0, scm_env s h = (l, h0) -> h0 = skipn (length s) h.
+  Proof.
+    induction s.
+    + simpl; intros. injection H; intuition.
+    + intros. destruct h.
+      - simpl in H. simpl. injection H; intuition.
+      - simpl in H. simpl. destruct (scm_env s h) eqn:e. injection H. intros. 
+        subst. apply (IHs _ _ _ e).
+  Qed.
+
+  Lemma skipn_skipn {A} m n : forall (l : list A), skipn m (skipn n l) = skipn (m+n) l.
+  Proof.
+    induction n.
+    + simpl; intuition. replace (m + 0) with m. reflexivity. omega.
+    + intro. destruct l.
+      - simpl. destruct m; simpl; intuition.
+      - replace (m + S n) with (S (m + n)). simpl. apply IHn.
+        omega.
+  Qed.
+
+  Lemma skipn_append {A} (l1 l2 : list A) : skipn (length l1) (l1 ++ l2) = l2.
+  Proof.
+    induction l1; simpl; intuition.
+  Qed.
+
+  Lemma nth_error_ctx_env_app_eq G2 n : forall G1 h1 h2,
+      length (concat G1) = length h1 ->
+      length (concat G2) = length h2 ->
+      nth_error (ctx_env (G2 ++ G1) (h2 ++ h1)) (length G2 + n)
+      = nth_error (ctx_env G1 h1) n.
+  Proof.
+    induction G2; simpl; intuition.
+    + replace h2 with (@List.nil Value). reflexivity.
+      symmetry. apply length_zero_iff_nil. intuition.
+    + destruct (scm_env a (h2++h1)) eqn:e. rewrite app_length in H0.
+      enough (length (h2++h1) = length (List.concat (a::G2++G1))).
+      destruct (p_scm_preenv _ _ _ H1 _ _ e).
+      simpl in H1. rewrite concat_app in H1. repeat rewrite app_length in H1.
+      enough (length p = length (concat G2) + length (concat G1)).
+      rewrite <- (firstn_skipn (length (concat G2)) p).
+      replace (skipn (length (concat G2)) p) with h1.
+      apply IHG2. exact H. rewrite firstn_length. rewrite H4. rewrite min_l. reflexivity. omega.
+      rewrite (scm_env_skipn _ _ _ _ e). 
+      rewrite skipn_skipn. 
+      replace (length (concat G2) + length a) with (length h2). symmetry. apply skipn_append.
+      omega.
+      rewrite H3. rewrite app_length. omega.
+      simpl. rewrite concat_app. do 3 rewrite app_length. omega.
+  Qed.
+
+  Lemma length_env {G} (h: env G) : length (projT1 h) = length (concat G).
+  Proof.
+    destruct h. simpl. symmetry. apply Nat.eqb_eq. exact e.
+  Qed.
+
+  Definition env_of_list (G:Ctx) : forall (l: list Value), length l = length (List.concat G) -> env G.
+    intros. exists l. apply Nat.eqb_eq. intuition.
+  Defined.
+
+  Lemma bool_eq_pi : forall (b1 b2 : bool) (e1 e2 : b1 = b2), e1 = e2.
+  Proof.
+    intros b1 b2. enough (forall (x y : bool), x = y \/ x <> y).
+    destruct b1, b2. 
+    + intro. eapply (K_dec H (fun e => forall e2 : true = true, e = e2) _ e1). Unshelve.
+      simpl. intro. eapply (K_dec H (fun e => eq_refl = e) _ e2). Unshelve. reflexivity.
+    + intros. discriminate e1.
+    + intros. discriminate e1.
+    + intro. eapply (K_dec H (fun e => forall e2 : false = false, e = e2) _ e1). Unshelve.
+      simpl. intro. eapply (K_dec H (fun e => eq_refl = e) _ e2). Unshelve. reflexivity.
+    + intros. destruct (Bool.bool_dec x y); intuition.
+  Qed.
+
+  Lemma env_eq {G} (h1 h2: env G) : projT1 h1 = projT1 h2 -> h1 = h2.
+  Proof.
+    destruct h1. destruct h2. simpl. intro. subst. f_equal. apply bool_eq_pi.
+  Qed.
+
+  Lemma env_JMeq {G1} {G2} (h1: env G1) (h2: env G2): G1 = G2 -> projT1 h1 = projT1 h2 -> h1 ~= h2.
+  Proof.
+    intro. subst.
+    destruct h1. destruct h2. simpl. intro. subst. apply eq_JMeq. f_equal. apply bool_eq_pi.
+  Qed.
+
+  Inductive j_fvar_sem : forall G, nat -> Name -> (env G -> Value) -> Prop :=
+  | jfs_hd : forall s G a, 
+      forall Sa, j_var_sem s a Sa -> j_fvar_sem (s::G) O a (fun h => Sa (@subenv1 (s::List.nil) G h))
+  | jfs_tl : forall s G i a,
+      forall Sia, j_fvar_sem G i a Sia -> j_fvar_sem (s::G) (S i) a (fun h => Sia (@subenv2 (s::List.nil) G h)).
+
+  Theorem j_fvar_sem_fun :
+    forall G i a Sia, j_fvar_sem G i a Sia -> forall Sia0, j_fvar_sem G i a Sia0 -> Sia = Sia0.
+  Proof.
+    intros G i a Sia Hia. induction Hia.
+    + intros. inversion H0. apply (existT_eq_elim H2); clear H2; intros; subst. clear H2.
+      rewrite (j_var_sem_fun _ _ _ H _ H5). reflexivity.
+    + intros. inversion H. apply (existT_eq_elim H5); clear H5; intros; subst.
+      rewrite (IHHia _ H4). reflexivity.
+  Qed.
+
+  Lemma j_var_sem_skip s a Sa s0:
+    j_var_sem s a Sa -> 
+    forall Sa', j_var_sem (s0 ++ s) a Sa' ->
+    forall h, Sa' h = Sa (env_skip h).
+  Proof.
+    intros H1. elim s0.
+    + intros. simpl. replace Sa' with Sa. reflexivity.
+      eapply j_var_sem_fun. exact H1. exact H.
+    + simpl; intros a0 s1 IH Sa' HSa' h. inversion HSa'.
+      - contradiction H3. (* by H1 *) admit.
+      - rewrite <- (IH _ H5). apply (existT_eq_elim H2).
+        intros _ Heq. rewrite <- Heq. reflexivity.
+  Admitted.
+
+  Lemma j_var_sem_inside s0 s a Sa :
+    j_var_sem (s0 ++ a :: s) a Sa ->
+    forall h, Sa h = env_hd (env_skip h).
+  Proof.
+    intros H1 h. enough (~ List.In a s).
+    generalize (jvs_hd a s H). intro H2.
+    apply (j_var_sem_skip _ _ _ _ H2 _ H1).
+    (* by H1 *)
+    admit.
+  Admitted.
+
+  Lemma j_fvar_sem_inside s0 a s G Sa : 
+    j_fvar_sem ((s0 ++ a :: s)::G) 0 a Sa ->
+    forall h, Sa h = env_hd (env_skip (@subenv1 ((s0 ++ a :: s)::List.nil) _ h)).
+  Proof.
+    intros H1 h. inversion H1; subst. apply (existT_eq_elim H0); intros; subst; clear H0 H.
+    apply (j_var_sem_inside _ _ _ _ H4).
+  Qed.
+
+
+End Evl.
+
+Module Type SEM (Db : DB).
+  Import Db.
+  Parameter B : Type.
+  Parameter btrue : B.
+  Parameter bfalse : B.
+  Parameter bmaybe : B.
+  Parameter band : B -> B -> B.
+  Parameter bor : B -> B -> B.
+  Parameter bneg : B -> B.
+  Parameter is_btrue : B -> bool.
+  Parameter is_bfalse : B -> bool.
+  Parameter of_bool : bool -> B.
+  Parameter veq : Value -> Value -> B.
+
+  Hypothesis sem_bpred : forall n, (forall l : list BaseConst, length l = n -> bool) -> 
+    forall l : list Value, length l = n -> B.
+
+  Hypothesis sem_bpred_elim : 
+    forall n (p : forall l, length l = n -> bool) (l : list Value) (Hl : length l = n) (P : B -> Prop),
+    (forall cl, monadic_map (fun val => val) l = Some cl -> forall Hcl : length cl = n, P (of_bool (p cl Hcl))) ->
+    (monadic_map (fun val => val) l = None -> P bmaybe) ->
+    P (sem_bpred n p l Hl).
+End SEM.
+
+Module Sem2 (Db : DB) <: SEM Db.
+  Import Db.
+  Definition B := bool.
+  Definition btrue := true.
+  Definition bfalse := false.
+  Definition bmaybe := false.
+  Definition band := andb.
+  Definition bor := orb.
+  Definition bneg := negb.
+  Definition is_btrue := fun (x : bool) => x.
+  Definition is_bfalse := fun (x : bool) => negb x.
+  Definition of_bool := fun (x : bool) => x.
+  Definition veq := fun v1 v2 => 
+    match v1, v2 with
+    | Some x1, Some x2 => c_eq x1 x2
+    | _, _ => false
+    end.
+
+  Definition sem_bpred_aux
+  : forall n (p : (forall l : list BaseConst, length l = n -> bool)), 
+      forall (l : list Value), length l = n -> 
+      { b : B & (forall x Hx, monadic_map (fun val => val) l = Some x -> b = of_bool (p x Hx)) /\
+                (monadic_map (fun val => val) l = None -> b = false)}.
+  Proof.
+    intros n p l H.
+    destruct (monadic_map (fun val => val) l) eqn:e.
+    + eexists (of_bool (p l0 _)). Unshelve. Focus 2. 
+      rewrite <- (length_monadic_map _ _ _ _ _ e). exact H. split.
+      - intros. injection H0. intro. generalize Hx. clear Hx. rewrite <- H1.
+        intro. f_equal. f_equal. eapply UIP.
+      - intro Hfalse. discriminate Hfalse.
+    + exists false. split; intros.
+      - discriminate H0.
+      - reflexivity.
+  Defined.
+
+  Definition sem_bpred 
+  : forall n, (forall l : list BaseConst, length l = n -> bool) -> 
+      forall l : list Value, length l = n -> B :=
+  fun n p l H => projT1 (sem_bpred_aux n p l H).
+
+  Lemma sem_bpred_elim n (p : forall l, length l = n -> bool) (l : list Value) (Hl : length l = n) (P : B -> Prop) :
+    (forall cl, monadic_map (fun val => val) l = Some cl -> forall Hcl : length cl = n, P (of_bool (p cl Hcl))) ->
+    (monadic_map (fun val => val) l = None -> P false) ->
+    P (sem_bpred n p l Hl).
+  intros. cut ((forall x Hx, monadic_map (fun val => val) l = Some x -> sem_bpred n p l Hl = of_bool (p x Hx)) /\
+                (monadic_map (fun val => val) l = None -> sem_bpred n p l Hl = false)).
+  + intro Hcut. destruct Hcut. destruct (monadic_map (fun val => val) l) eqn:e; simpl.
+    - assert (length l0 = n). rewrite <- Hl. symmetry. apply (length_monadic_map _ _ _ _ _ e).
+      rewrite (H1 _ H3). apply H. reflexivity. reflexivity.
+    - rewrite (H2 eq_refl). apply H0. reflexivity.
+  + apply (projT2 (sem_bpred_aux n p l Hl)).
+  Qed.
+
+End Sem2.
+
+Module Sem3 (Db : DB) <: SEM Db.
+  Import Db.
+  Definition B := tribool.
+  Definition btrue := ttrue.
+  Definition bfalse := tfalse.
+  Definition bmaybe := unknown.
+  Definition band := andtb.
+  Definition bor := ortb.
+  Definition bneg := negtb.
+  Definition is_btrue := Tribool.eqb ttrue.
+  Definition is_bfalse := Tribool.eqb tfalse.
+  Definition of_bool := tribool_of_bool.
+  Definition veq := fun v1 v2 => 
+    match v1, v2 with
+    | Some x1, Some x2 => tribool_of_bool (c_eq x1 x2)
+    | _, _ => unknown
+    end.
+
+  Definition sem_bpred_aux
+  : forall n (p : (forall l : list BaseConst, length l = n -> bool)), 
+      forall (l : list Value), length l = n -> 
+      { b : B & (forall x Hx, monadic_map (fun val => val) l = Some x -> b = of_bool (p x Hx)) /\
+                (monadic_map (fun val => val) l = None -> b = unknown)}.
+  Proof.
+    intros n p l H.
+    destruct (monadic_map (fun val => val) l) eqn:e.
+    + eexists (of_bool (p l0 _)). Unshelve. Focus 2. 
+      rewrite <- (length_monadic_map _ _ _ _ _ e). exact H. split.
+      - intros. injection H0. intro. generalize Hx. clear Hx. rewrite <- H1.
+        intro. f_equal. f_equal. eapply UIP.
+      - intro Hfalse. discriminate Hfalse.
+    + exists unknown. split; intros.
+      - discriminate H0.
+      - reflexivity.
+  Defined.
+
+  Definition sem_bpred 
+  : forall n, (forall l : list BaseConst, length l = n -> bool) -> 
+      forall l : list Value, length l = n -> B :=
+  fun n p l H => projT1 (sem_bpred_aux n p l H).
+
+  Lemma sem_bpred_elim n (p : forall l, length l = n -> bool) (l : list Value) (Hl : length l = n) (P : B -> Prop) :
+    (forall cl, monadic_map (fun val => val) l = Some cl -> forall Hcl : length cl = n, P (of_bool (p cl Hcl))) ->
+    (monadic_map (fun val => val) l = None -> P unknown) ->
+    P (sem_bpred n p l Hl).
+  intros. cut ((forall x Hx, monadic_map (fun val => val) l = Some x -> sem_bpred n p l Hl = of_bool (p x Hx)) /\
+                (monadic_map (fun val => val) l = None -> sem_bpred n p l Hl = unknown)).
+  + intro Hcut. destruct Hcut. destruct (monadic_map (fun val => val) l) eqn:e; simpl.
+    - assert (length l0 = n). rewrite <- Hl. symmetry. apply (length_monadic_map _ _ _ _ _ e).
+      rewrite (H1 _ H3). apply H. reflexivity. reflexivity.
+    - rewrite (H2 eq_refl). apply H0. reflexivity.
+  + apply (projT2 (sem_bpred_aux n p l Hl)).
+  Qed.
+
+End Sem3.
+

--- a/Eval.v
+++ b/Eval.v
@@ -467,6 +467,15 @@ Module Type SEM.
   Parameter of_bool : bool -> B.
   Parameter veq : Value -> Value -> B.
 
+  Hypothesis is_btrue_btrue : is_btrue btrue = true.
+  Hypothesis is_btrue_bfalse : is_btrue bfalse = false.
+  Hypothesis is_bfalse_btrue : is_bfalse btrue = false.
+  Hypothesis is_bfalse_bfalse : is_bfalse bfalse = true.
+
+  Hypothesis band_of_bool : forall x y, band (of_bool x) (of_bool y) = of_bool (andb x y).
+  Hypothesis bor_of_bool : forall x y, bor (of_bool x) (of_bool y) = of_bool (orb x y).
+  Hypothesis bneg_of_bool : forall x, bneg (of_bool x) = of_bool (negb x).
+
   Hypothesis sem_bpred : forall n, (forall l : list BaseConst, length l = n -> bool) -> 
     forall l : list Value, length l = n -> B.
 
@@ -494,6 +503,24 @@ Module Sem2 <: SEM.
     | Some x1, Some x2 => c_eq x1 x2
     | _, _ => false
     end.
+
+  Lemma is_btrue_btrue : is_btrue btrue = true. Proof. reflexivity. Qed.
+  Lemma is_btrue_bfalse : is_btrue bfalse = false. Proof. reflexivity. Qed.
+  Lemma is_bfalse_btrue : is_bfalse btrue = false. Proof. reflexivity. Qed.
+  Lemma is_bfalse_bfalse : is_bfalse bfalse = true. Proof. reflexivity. Qed.
+
+  Lemma band_of_bool : forall x y, band (of_bool x) (of_bool y) = of_bool (andb x y).
+  Proof.
+    intros. destruct x; destruct y; reflexivity.
+  Qed.
+  Lemma bor_of_bool : forall x y, bor (of_bool x) (of_bool y) = of_bool (orb x y).
+  Proof.
+    intros. destruct x; destruct y; reflexivity.
+  Qed.
+  Lemma bneg_of_bool : forall x, bneg (of_bool x) = of_bool (negb x).
+  Proof.
+    intros. destruct x; reflexivity.
+  Qed.
 
   Definition sem_bpred_aux
   : forall n (p : (forall l : list BaseConst, length l = n -> bool)), 
@@ -550,6 +577,24 @@ Module Sem3 <: SEM.
     | Some x1, Some x2 => tribool_of_bool (c_eq x1 x2)
     | _, _ => unknown
     end.
+
+  Lemma is_btrue_btrue : is_btrue btrue = true. Proof. reflexivity. Qed.
+  Lemma is_btrue_bfalse : is_btrue bfalse = false. Proof. reflexivity. Qed.
+  Lemma is_bfalse_btrue : is_bfalse btrue = false. Proof. reflexivity. Qed.
+  Lemma is_bfalse_bfalse : is_bfalse bfalse = true. Proof. reflexivity. Qed.
+
+  Lemma band_of_bool : forall x y, band (of_bool x) (of_bool y) = of_bool (andb x y).
+  Proof.
+    intros. destruct x; destruct y; reflexivity.
+  Qed.
+  Lemma bor_of_bool : forall x y, bor (of_bool x) (of_bool y) = of_bool (orb x y).
+  Proof.
+    intros. destruct x; destruct y; reflexivity.
+  Qed.
+  Lemma bneg_of_bool : forall x, bneg (of_bool x) = of_bool (negb x).
+  Proof.
+    intros. destruct x; reflexivity.
+  Qed.
 
   Definition sem_bpred_aux
   : forall n (p : (forall l : list BaseConst, length l = n -> bool)), 

--- a/ListRelation.v
+++ b/ListRelation.v
@@ -411,20 +411,6 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
         intro. rewrite H0 in Hfat. rewrite (proj2 (T_eqb_eq _ _ _) eq_refl) in Hfat. discriminate Hfat.
   Qed.
 
-  Lemma list_sum_O l : (forall x, List.In x l -> x = 0) -> list_sum l = O.
-  Proof.
-    elim l; eauto. intros; simpl. rewrite (H0 a). apply H. 
-    intros; apply H0. right; exact H1. left; reflexivity.
-  Qed.
-
-  Lemma list_sum_O' l : list_sum l = O -> forall x, List.In x l -> x = O.
-  Proof.
-    elim l.
-    simpl; intros; contradiction H0.
-    simpl; intros. destruct (plus_is_O _ _ H0). destruct H1; eauto.
-    rewrite <- H1. exact H2.
-  Qed.
-
   Lemma count_occ_list_rcomp {m} {n} l (f : T m -> list (T n)) :
     forall t,
     count_occ (OV.veq_dec n) (list_rcomp l f) t =

--- a/ListRelation.v
+++ b/ListRelation.v
@@ -493,6 +493,13 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
     rewrite <- count_occ_sort. clear e. unfold list_comp. 
     rewrite (count_occ_list_comp _ _ _ _ List.nil); reflexivity.
   Qed.
+  Lemma p_rsum : forall m n, forall r : R m, forall f : T m -> R n, forall t, 
+                    memb (rsum r f) t = list_sum (List.map (fun t0 => memb r t0 * memb (f t0) t) (supp r)).
+  Proof.
+    intros. destruct r. unfold memb, supp; simpl.
+    rewrite <- count_occ_sort. clear e.
+    rewrite count_occ_list_rcomp; reflexivity.
+  Qed.
 
   Lemma p_self : forall n, forall r : R n, forall p t, p t = false -> memb (sel r p) t = 0.
   Proof.
@@ -545,12 +552,20 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
     destruct e. apply JMeq_eq. destruct e0. reflexivity.
   Qed.
 
-  Axiom Rsingle : forall n, T n -> R n.
-  Implicit Arguments Rsingle [n].
-
-  Axiom p_rsum : forall m n, forall r : R m, forall f : T m -> R n, forall t,
-                    memb (rsum r f) t = list_sum (List.map (fun t0 => memb r t0 * memb (f t0) t) (supp r)).
-  Axiom p_single : forall n (t : T n), memb (Rsingle t) t = 1.
-  Axiom p_single_neq : forall n (t1 t2 : T n), t1 <> t2 -> memb (Rsingle t1) t2 = 0.
+  Definition Rsingle {n} : T n -> R n :=
+    fun t => sum Rone (fun _ => t).
+  Lemma p_single : forall n (t : T n), memb (Rsingle t) t = 1.
+  Proof.
+    intros. unfold Rsingle. rewrite p_sum. replace (T_eqb t t) with true. 
+    simpl. rewrite p_one. omega.
+    rewrite (proj2 (T_eqb_eq _ _ _) eq_refl). reflexivity.
+  Qed.
+  Lemma p_single_neq : forall n (t1 t2 : T n), t1 <> t2 -> memb (Rsingle t1) t2 = 0.
+  Proof.
+    intros. unfold Rsingle. rewrite p_sum. replace (T_eqb t1 t2) with false. simpl. reflexivity.
+    destruct (T_eqb t1 t2) eqn:e.
+    contradiction H. eapply (proj1 (T_eqb_eq _ _ _)). exact e.
+    reflexivity.
+  Qed.
 
 End MultiSet.

--- a/ListRelation.v
+++ b/ListRelation.v
@@ -76,6 +76,7 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
   Implicit Arguments times [m n].
   Implicit Arguments sum [m n].
   Implicit Arguments sel [n].
+  Implicit Arguments rsum [m n].
 
   Definition card {n} := fun S => memb (@sum n 0 S (fun _ => Vector.nil _)) (Vector.nil _).
 
@@ -166,11 +167,6 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
     apply IHl. simpl in H. destruct (dec a x); intuition.
     rewrite count_occ_app. rewrite H0. rewrite count_occ_repeat_neq. reflexivity.
     simpl in H. destruct (dec a x); intuition.
-  Qed.
-
-  Lemma or_eq_lt_n_O n : n = 0 \/ 0 < n.
-  Proof.
-    destruct (Nat.eq_dec n 0); intuition.
   Qed.
 
   Lemma count_occ_nodup {A} {dec} l (x:A) : 
@@ -562,9 +558,6 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
     generalize e; clear e. rewrite H0. intros. f_equal.
     destruct e. apply JMeq_eq. destruct e0. reflexivity.
   Qed.
-
-  Axiom rsum  : forall m n, R m -> (T m -> R n) -> R n.
-  Implicit Arguments rsum [m n].
 
   Axiom Rsingle : forall n, T n -> R n.
   Implicit Arguments Rsingle [n].

--- a/ListRelation.v
+++ b/ListRelation.v
@@ -45,6 +45,14 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
       let l := nodup (OV.veq_dec _) l0 in
       List.fold_left (fun acc x => acc ++
         repeat (f x) (count_occ (OV.veq_dec _) l0 x)) l List.nil.
+  Definition list_rcomp {m} {n} : list (T m) -> (T m -> list (T n)) -> list (T n)
+    := fun l f =>
+      let l1 := nodup (OV.veq_dec _) l in
+      let l2 := nodup (OV.veq_dec _) (List.concat (List.map f l)) in
+      List.fold_left 
+        (fun acc t => acc ++ repeat t
+          (list_sum (List.map (fun u => count_occ (OV.veq_dec _) l u * count_occ (OV.veq_dec _) (f u) t) l1)))
+        l2 List.nil.
 
   (* public operations *)
   Definition memb {n} := fun (r : R n) t => count_occ (OV.veq_dec n) (projT1 r) t.
@@ -58,6 +66,8 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
     := fun A B => existT _ (sort (list_times (projT1 A) (projT1 B))) (sort_is_sorted _).
   Definition sum {m} {n} : R m -> (T m -> T n) -> R n
     := fun A f => existT _ (sort (list_comp (projT1 A) f)) (sort_is_sorted _).
+  Definition rsum {m} {n} : R m -> (T m -> R n) -> R n
+    := fun A f => existT _ (sort (list_rcomp (projT1 A) (fun x => projT1 (f x)))) (sort_is_sorted _).
   Definition sel {n} : R n -> (T n -> bool) -> R n
     := fun A p => existT _ (sort (List.filter p (projT1 A))) (sort_is_sorted _).
   Definition flat {n} : R n -> R n := fun A => existT _ (sort (nodup (OV.veq_dec n) (projT1 A))) (sort_is_sorted _).
@@ -69,7 +79,7 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
 
   Definition card {n} := fun S => memb (@sum n 0 S (fun _ => Vector.nil _)) (Vector.nil _).
 
-  Definition Rnil : R 0 := existT _ (sort List.nil) (sort_is_sorted _).
+  Definition Rnil {n} : R n := existT _ (sort List.nil) (sort_is_sorted _).
   Definition Rone : R 0 := existT _ (sort (List.cons (Vector.nil _) List.nil)) (sort_is_sorted _).
   (* generalized cartesian product of m relations, each taken with its arity n *)
   Fixpoint prod (Rl : list { n : nat & R n }) 
@@ -405,6 +415,58 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
         intro. rewrite H0 in Hfat. rewrite (proj2 (T_eqb_eq _ _ _) eq_refl) in Hfat. discriminate Hfat.
   Qed.
 
+  Lemma list_sum_O l : (forall x, List.In x l -> x = 0) -> list_sum l = O.
+  Proof.
+    elim l; eauto. intros; simpl. rewrite (H0 a). apply H. 
+    intros; apply H0. right; exact H1. left; reflexivity.
+  Qed.
+
+  Lemma list_sum_O' l : list_sum l = O -> forall x, List.In x l -> x = O.
+  Proof.
+    elim l.
+    simpl; intros; contradiction H0.
+    simpl; intros. destruct (plus_is_O _ _ H0). destruct H1; eauto.
+    rewrite <- H1. exact H2.
+  Qed.
+
+  Lemma count_occ_list_rcomp {m} {n} l (f : T m -> list (T n)) :
+    forall t,
+    count_occ (OV.veq_dec n) (list_rcomp l f) t =
+    list_sum (List.map 
+      (fun u => count_occ (OV.veq_dec _) l u * count_occ (OV.veq_dec _) (f u) t) 
+      (nodup (OV.veq_dec _) l)).
+  Proof.
+    intro. simpl. unfold list_rcomp.
+    destruct (or_eq_lt_n_O (count_occ (OV.veq_dec n) (nodup (OV.veq_dec n) (concat (List.map f l))) t)).
+    rewrite list_sum_O. rewrite count_occ_fold'; eauto.
+    enough (count_occ (OV.veq_dec _) (List.concat (List.map f l)) t = O). clear H.
+    intros.
+    enough (List.In x (List.map (fun u => count_occ (OV.veq_dec _) l u * count_occ (OV.veq_dec _) (f u) t) l)).
+    clear H. induction l in H0, H1 at 2 |- *.
+    simpl in H1. contradiction.
+    rewrite List.map_cons, concat_cons, count_occ_app in H0. destruct (plus_is_O _ _ H0); clear H0.
+    rewrite List.map_cons in H1. destruct H1.
+    rewrite <- H0, H. omega.
+    apply IHl0. apply H2.
+    apply H0.
+    destruct (List.in_map_iff
+     (fun u => count_occ (OV.veq_dec _) l u * count_occ (OV.veq_dec _) (f u) t)
+     (nodup (OV.veq_dec _) l) x).
+    destruct (H1 H); clear H1 H2. destruct H3.
+    destruct (List.in_map_iff
+     (fun u => count_occ (OV.veq_dec _) l u * count_occ (OV.veq_dec _) (f u) t)
+     l x).
+    apply H4. rewrite <- H1. exists x0. split; auto.
+    destruct (nodup_In (OV.veq_dec _) l x0). auto.
+    destruct (@count_occ_nodup_O _ (OV.veq_dec _) (concat (List.map f l)) t). auto.
+
+    rewrite (count_occ_fold (nodup (OV.veq_dec n) (concat (List.map f l))) List.nil); eauto.
+    apply NoDup_nodup.
+    intros. destruct H0.
+    rewrite H1 in H0. intuition.
+    simpl in H0. intuition.
+  Qed.
+
   (* public properties *)
   Lemma p_fs : forall n, forall r : R n, forall t, memb r t > 0 -> List.In t (supp r).
   Proof.
@@ -480,7 +542,7 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
       apply count_occ_nodup_O. apply count_occ_not_In. exact n0.
       symmetry. apply count_occ_not_In. exact n0.
   Qed.
-  Lemma p_nil : forall t, memb Rnil t = 0.
+  Lemma p_nil : forall n (t : T n), memb Rnil t = 0.
   Proof.
     intros. reflexivity.
   Qed.
@@ -500,5 +562,16 @@ Module MultiSet (O : OrdType.OrdType) <: REL.
     generalize e; clear e. rewrite H0. intros. f_equal.
     destruct e. apply JMeq_eq. destruct e0. reflexivity.
   Qed.
+
+  Axiom rsum  : forall m n, R m -> (T m -> R n) -> R n.
+  Implicit Arguments rsum [m n].
+
+  Axiom Rsingle : forall n, T n -> R n.
+  Implicit Arguments Rsingle [n].
+
+  Axiom p_rsum : forall m n, forall r : R m, forall f : T m -> R n, forall t,
+                    memb (rsum r f) t = list_sum (List.map (fun t0 => memb r t0 * memb (f t0) t) (supp r)).
+  Axiom p_single : forall n (t : T n), memb (Rsingle t) t = 1.
+  Axiom p_single_neq : forall n (t1 t2 : T n), t1 <> t2 -> memb (Rsingle t1) t2 = 0.
 
 End MultiSet.

--- a/RcSemantics.v
+++ b/RcSemantics.v
@@ -1,0 +1,121 @@
+Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat RcSyntax AbstractRelation Bool.Sumbool Tribool JMeq 
+  FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Util Common Eval SemFacts.
+
+Module RcSemantics (Db : DB) (Sem: SEM Db) (Rc : RC Db).
+  Import Db.
+  Import Rc.
+  Import Sem.
+  Module Ev := Evl Db.
+  Import Ev.
+  Module SF := SemFacts.Facts Db.
+  Import SF.
+
+  (* alternate -- not stronger but easier -- version of sum *)
+
+  Axiom R_sum : forall m n, Rel.R m -> (Rel.T m -> Rel.R n) -> Rel.R n.
+  Implicit Arguments R_sum [m n].
+
+  (* singleton rel *)
+  Definition R_single {m} : Rel.T m -> Rel.R m :=
+    fun t => Rel.sum Rel.Rone (fun _ => t).
+
+  Definition sem_empty : forall n, Rel.R n -> B :=
+    fun n r => of_bool(Rel.card r =? 0).
+
+  Definition sem_nil : forall n, Rel.R n.
+    intro n.
+    epose (r := Rel.Rsingle (cast _ _ _ (of_list (List.repeat None n)))).
+    apply (Rel.sel r (fun _ => false)).
+    Unshelve.
+    rewrite repeat_length. reflexivity.
+  Defined.
+
+  Axiom env_of_tuple : forall G, Db.Rel.T (list_sum (List.map (List.length (A:=Name)) G)) -> env G.
+
+  Inductive j_base_sem (d : Db.D) : forall G (t :  tm), (env G -> Value) -> Prop :=
+  | jbs_cst  : forall G c,
+      j_base_sem d G (cst c) (fun _ => Db.c_sem c)
+  | jbs_null : forall G, j_base_sem d G null (fun _ => None)
+  | jbs_proj : forall G i a,
+      forall Sia,
+      j_fvar_sem G i a Sia -> j_base_sem d G (proj (var i) a) Sia.
+
+  Inductive j_basel_sem (d : Db.D) : forall G (tml : list tm), (env G -> Rel.T (List.length tml)) -> Prop :=
+  | jbls_nil  : forall G, j_basel_sem d G List.nil (fun _ => Vector.nil _)
+  | jbls_cons : forall G t tml,
+      forall St Stml,
+      j_base_sem d G t St -> j_basel_sem d G tml Stml ->
+      j_basel_sem d G (t::tml) (fun h => Vector.cons _ (St h) _ (Stml h)).
+
+  Inductive j_tuple_sem (d : Db.D) : forall G (t:tm) (s:Scm), (env G -> Rel.T (List.length s)) -> Prop :=
+  | jts_mktup : forall G al bl,
+      forall e Sbl, List.NoDup al -> List.length al = List.length bl -> j_basel_sem d G bl Sbl ->
+      j_tuple_sem d G (mktup (List.combine al bl)) al (cast _ _ e Sbl).
+
+  Inductive j_cond_sem (d : Db.D) : forall G (t:tm), (env G -> B) -> Prop :=
+  | jws_empty : forall G q b n, 
+      forall Sq, j_coll_sem d G q b n Sq ->
+      j_cond_sem d G (empty b q) (fun h => sem_empty _ (Sq h))
+  | jws_pred : forall G n p tml,
+     forall Stml e,
+     j_basel_sem d G tml Stml ->
+     j_cond_sem d G (pred n p tml) 
+       (fun Vl => Sem.sem_bpred _ p (to_list (Stml Vl)) (eq_trans (length_to_list _ _ _) e))
+
+  with j_coll_sem (d : Db.D) : forall G (t : tm) (b:bool) (s:Scm), (env G -> Rel.R (List.length s)) -> Prop :=
+  | jcs_nnil : forall G b s,
+     j_coll_sem d G (nil b s) b s (fun h => sem_nil _)
+  | jcs_ndisj : forall G t b s,
+     forall St,
+     j_disjunct_sem d G t b s St ->
+     j_coll_sem d G t b s St
+  | jcs_nunion : forall G t1 t2 b s,
+      forall St1 St2,
+      j_disjunct_sem d G t1 b s St1 ->
+      j_coll_sem d G t2 b s St2 ->
+      let S := fun h => if b then Rel.flat (Rel.plus (St1 h) (St2 h)) else Rel.plus (St1 h) (St2 h) in
+      j_coll_sem d G (union t1 t2) b s S
+
+  with j_disjunct_sem (d : Db.D) : forall G (t : tm) (b : bool) (s:Scm), (env G -> Rel.R (List.length s)) -> Prop :=
+  | jds_single : forall G b tup c,
+      forall stup Stup Sc, j_tuple_sem d G tup stup Stup -> j_cond_sem d G c Sc ->
+      j_disjunct_sem d G (cwhere (single b tup) c) b stup 
+        (fun h => if Sem.is_btrue (Sc h) then Rel.Rsingle (Stup h) else sem_nil _)
+  | jds_comprn : forall G q1 q2,
+      forall b sq2 Sq2 sq1 Sq1 e,
+      j_gen_sem d G q2 b sq2 Sq2 ->
+      j_disjunct_sem d (sq2::G) q1 b sq1 Sq1 ->
+      j_disjunct_sem d G (comprn q1 q2) b sq1 (fun h =>
+        let f := fun (Vl : Rel.T (length sq2)) => Sq1 (env_app _ _ (env_of_tuple (sq2::List.nil) (cast _ _ e Vl)) h) in
+        let S := Rel.rsum (Sq2 h) f in
+        if b then Rel.flat S else S)
+
+  with j_gen_sem (d : Db.D) : forall G (t : tm) (b : bool) (s : Scm), (env G -> Rel.R (List.length s)) -> Prop :=
+  | jgs_tab : forall G x,
+      forall s (e : Db.db_schema d x = Some s),
+      j_gen_sem d G (tab x) false _ (fun _ => Db.db_rel e)
+  | jgs_prom : forall G q,
+      forall s Sq,
+      j_coll_sem d G q true s Sq ->
+      j_gen_sem d G (prom q) false s Sq
+  | jgs_bagdiff : forall G q1 q2,
+      forall s Sq1 Sq2,
+      j_coll_sem d G q1 false s Sq1 -> j_coll_sem d G q2 false s Sq2 ->
+      j_gen_sem d G (diff q1 q2) false s (fun h => Rel.minus (Sq1 h) (Sq2 h))
+  | jgs_dtab : forall G x,
+      forall s (e : Db.db_schema d x = Some s),
+      j_gen_sem d G (dist (tab x)) true s (fun _ => Rel.flat (Db.db_rel e))
+  | jgs_ddiff : forall G q1 q2,
+      forall s Sq1 Sq2,
+      j_coll_sem d G q1 false s Sq1 -> j_coll_sem d G q2 false s Sq2 ->
+      j_gen_sem d G (dist (diff q1 q2)) true s (fun h => Rel.flat (Rel.minus (Sq1 h) (Sq2 h))).
+
+  Scheme jws_ind_mut   := Induction for j_cond_sem      Sort Prop
+  with   jcs_ind_mut   := Induction for j_coll_sem      Sort Prop
+  with   jds_ind_mut   := Induction for j_disjunct_sem  Sort Prop
+  with   jgs_ind_mut   := Induction for j_gen_sem       Sort Prop.
+
+  Combined Scheme j_sem_ind_mut from jws_ind_mut, jcs_ind_mut, jds_ind_mut, jgs_ind_mut.
+
+
+End RcSemantics.

--- a/RcSemantics.v
+++ b/RcSemantics.v
@@ -1,13 +1,12 @@
 Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat RcSyntax AbstractRelation Bool.Sumbool Tribool JMeq 
   FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Util Common Eval SemFacts.
 
-Module RcSemantics (Db : DB) (Sem: SEM Db) (Rc : RC Db).
+Module RcSemantics (Sem: SEM) (Rc : RC).
   Import Db.
   Import Rc.
   Import Sem.
-  Module Ev := Evl Db.
-  Import Ev.
-  Module SF := SemFacts.Facts Db.
+  Import Evl.
+  Module SF := SemFacts.Facts.
   Import SF.
 
   (* alternate -- not stronger but easier -- version of sum *)

--- a/RcSemantics.v
+++ b/RcSemantics.v
@@ -29,8 +29,6 @@ Module RcSemantics (Sem: SEM) (Rc : RC).
     rewrite repeat_length. reflexivity.
   Defined.
 
-  Axiom env_of_tuple : forall G, Db.Rel.T (list_sum (List.map (List.length (A:=Name)) G)) -> env G.
-
   Inductive j_base_sem (d : Db.D) : forall G (t :  tm), (env G -> Value) -> Prop :=
   | jbs_cst  : forall G c,
       j_base_sem d G (cst c) (fun _ => Db.c_sem c)
@@ -85,7 +83,7 @@ Module RcSemantics (Sem: SEM) (Rc : RC).
       j_gen_sem d G q2 b sq2 Sq2 ->
       j_disjunct_sem d (sq2::G) q1 b sq1 Sq1 ->
       j_disjunct_sem d G (comprn q1 q2) b sq1 (fun h =>
-        let f := fun (Vl : Rel.T (length sq2)) => Sq1 (env_app _ _ (env_of_tuple (sq2::List.nil) (cast _ _ e Vl)) h) in
+        let f := fun (Vl : Rel.T (length sq2)) => Sq1 (env_app _ _ (Evl.env_of_tuple (sq2::List.nil) (cast _ _ e Vl)) h) in
         let S := Rel.rsum (Sq2 h) f in
         if b then Rel.flat S else S)
 

--- a/RcSyntax.v
+++ b/RcSyntax.v
@@ -1,0 +1,137 @@
+Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat AbstractRelation Tribool Common.
+
+Axiom BaseConst : Type.
+Axiom Name : Type.
+
+Module Type RC (Db : DB).
+  Import Db.
+
+  Inductive tm :=
+  | cst    : BaseConst -> tm
+  | null   : tm
+  | pred   : forall n, (forall l : list BaseConst, length l = n -> bool) -> list tm -> tm
+  | var    : nat -> tm
+  | mktup  : list (Name * tm) -> tm
+  | proj   : tm -> Name -> tm
+  | tab    : Name -> tm
+  | nil    : bool -> Scm -> tm      (* is set, schema *)
+  | single : bool -> tm -> tm       (* is_set *)
+  | union  : tm -> tm -> tm
+  | inters : tm -> tm -> tm
+  | diff   : tm -> tm -> tm
+  | comprn : tm -> tm -> tm
+  | cwhere : tm -> tm -> tm
+  | dist   : tm -> tm
+  | prom   : tm -> tm
+  | empty  : bool -> tm -> tm
+  .
+
+  Inductive j_var (a : Name) : Scm -> Prop :=
+  | j_varhd   : forall s, ~ List.In a s -> j_var a (a::s)
+  | j_varcons : forall b s, a <> b -> j_var a s -> j_var a (b::s).
+
+  Inductive j_base (d : Db.D) : list Scm -> tm -> Prop :=
+  | j_cst  : forall g c, j_base d g (cst c)
+  | j_null : forall g, j_base d g null
+  | j_proj : forall g t x s, j_tuple d g t s -> j_var x s -> j_base d g (proj t x)
+
+  with j_tuple (d : Db.D) : list Scm -> tm -> Scm -> Prop :=
+  | j_tmvar : forall g n s, List.nth_error g n = Some s -> j_tuple d g (var n) s
+  | j_mktup : forall g bl, 
+      List.NoDup (List.map fst bl) ->
+      (forall g t, List.In t (List.map snd bl) -> j_base d g t)
+      -> j_tuple d g (mktup bl) (List.map fst bl).
+
+  Inductive j_cond (d : Db.D) : list Scm -> tm -> Prop :=
+  | j_empty : forall g q b s, j_coll d g q b s -> j_cond d g (empty b q)
+  | j_pred : forall g n p tl, 
+      (forall t, List.In t tl -> j_base d g t) -> length tl = n 
+      -> j_cond d g (pred n p tl)
+
+  with j_coll (d : Db.D) : list Scm -> tm -> bool -> Scm -> Prop :=
+  | j_tab : forall g x s, Db.db_schema d x = Some s -> j_coll d g (tab x) false s
+  | j_nil : forall g b s, j_coll d g (nil b s) b s
+  | j_single : forall g b t s, j_tuple d g t s -> j_coll d g (single b t) b s
+  | j_union : forall g q1 q2 b s, j_coll d g q1 b s -> j_coll d g q2 b s -> j_coll d g (union q1 q2) b s
+  | j_inters : forall g q1 q2 b s , j_coll d g q1 b s -> j_coll d g q2 b s -> j_coll d g (inters q1 q2) b s
+  | j_diff : forall g q1 q2 b s, j_coll d g q1 b s -> j_coll d g q2 b s -> j_coll d g (diff q1 q2) b s
+  | j_comprn : forall g q1 q2 b s1 s2, j_coll d g q2 b s2 -> j_coll d (s2::g) q1 b s1 -> j_coll d g (comprn q1 q2) b s1
+  | j_cwhere : forall g q s c b, j_coll d g q b s -> j_cond d g c -> j_coll d g (cwhere q c) b s
+  | j_dist : forall g q s, j_coll d g q false s -> j_coll d g (dist q) true s
+  | j_prom : forall g q s, j_coll d g q true s -> j_coll d g (prom q) false s.
+
+  Fixpoint bigunion (b : bool) (s : Scm) (ql : list tm) : tm :=
+    match ql with
+    | List.nil => nil b s
+    | q0::ql0 => union q0 (bigunion b s ql0)
+    end.
+
+  Fixpoint multi_comprn q ql : tm :=
+    match ql with
+    | List.nil => q
+    | q0::ql0 => multi_comprn (comprn q q0) ql0
+    end.
+
+  Definition not_union t := 
+    match t with
+    | union _ _ => false
+    | _ => true
+    end.
+
+
+  (* normal forms *)
+  Inductive j_nbase (d : Db.D) : list Scm -> tm -> Prop :=
+  | j_ncst  : forall g c, j_nbase d g (cst c)
+  | j_nnull  : forall g, j_nbase d g null
+  | j_nproj : forall g n x s, List.nth_error g n = Some s -> j_var x s -> j_nbase d g (proj (var n) x).
+
+  Definition j_nbasel d g tl := forall t, List.In t tl -> j_nbase d g t.
+
+  Inductive j_ntuple (d : Db.D) : list Scm -> tm -> Scm -> Prop :=
+  | j_nmktup : forall g bl, 
+      List.NoDup (List.map fst bl) -> j_nbasel d g (List.map snd bl)
+      -> j_ntuple d g (mktup bl) (List.map fst bl).
+
+  Inductive j_ncond (d : Db.D) : list Scm -> tm -> Prop :=
+  | j_nempty : forall g q b s, j_ncoll d g q b s -> j_ncond d g (empty b q)
+  | j_npred : forall g n p tl, 
+      j_nbasel d g tl -> length tl = n
+      -> j_ncond d g (pred n p tl)
+
+  with j_ncoll (d : Db.D) : list Scm -> tm -> bool -> Scm -> Prop :=
+  | j_ncnil : forall g b s, j_ncoll d g (nil b s) b s
+  | j_ncdisjunct : forall g t b s, not_union t = true -> j_ndisjunct d g t b s -> j_ncoll d g t b s
+  | j_ncunion : forall g t1 t2 b s, 
+      j_ndisjunct d g t1 b s ->
+      j_ncoll d g t2 b s
+      -> j_ncoll d g (union t1 t2) b s
+
+  with j_ndisjunct (d : Db.D) : list Scm -> tm -> bool -> Scm -> Prop :=
+  | j_nsingle : forall g b tup c, 
+      forall s, j_ntuple d g tup s -> j_ncond d g c
+      -> j_ndisjunct d g (cwhere (single b tup) c) b s
+  | j_ncomprn : forall g q1 q2,
+      forall b s s2, j_ngen d g q2 b s2 -> j_ndisjunct d (s2::g) q1 b s
+      -> j_ndisjunct d g (comprn q1 q2) b s
+
+  with j_ngen (d : Db.D) : list Scm -> tm -> bool -> Scm -> Prop :=
+  | j_ntab : forall g x s, Db.db_schema d x = Some s -> j_ngen d g (tab x) false s
+  | j_nprom : forall g q s, j_ncoll d g q true s -> j_ngen d g (prom q) false s
+  | j_nbagdiff : forall g q1 q2 s, 
+      j_ncoll d g q1 false s -> j_ncoll d g q2 false s 
+      -> j_ngen d g (diff q1 q2) false s
+  | j_ndtab : forall g x s, Db.db_schema d x = Some s -> j_ngen d g (dist (tab x)) true s
+  | j_nddiff : forall g q1 q2 s,
+      j_ncoll d g q1 false s -> j_ncoll d g q2 false s
+      -> j_ngen d g (dist (diff q1 q2)) true s
+  .
+
+  Scheme jnw_ind_mut := Induction for j_ncond      Sort Prop
+  with jnc_ind_mut   := Induction for j_ncoll      Sort Prop
+  with jnd_ind_mut   := Induction for j_ndisjunct  Sort Prop
+  with jng_ind_mut   := Induction for j_ngen       Sort Prop.
+
+  Combined Scheme j_norm_ind_mut from jnw_ind_mut, jnc_ind_mut, jnd_ind_mut, jng_ind_mut.
+
+
+End RC.

--- a/RcSyntax.v
+++ b/RcSyntax.v
@@ -1,9 +1,6 @@
 Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat AbstractRelation Tribool Common.
 
-Axiom BaseConst : Type.
-Axiom Name : Type.
-
-Module Type RC (Db : DB).
+Module Type RC.
   Import Db.
 
   Inductive tm :=

--- a/RcToSQL.v
+++ b/RcToSQL.v
@@ -1,0 +1,616 @@
+Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat RcSyntax AbstractRelation Bool.Sumbool Tribool JMeq 
+  FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Util Common Syntax SemFacts RelFacts Eval 
+  Semantics RcSemantics.
+
+Module RcToSql (Db : DB) (Sem : SEM Db) (Rc : RC Db) (Sql : SQL Db).
+  Import Db.
+  Import Rc.
+  Import Sql.
+
+  Module RF := RelFacts.Facts Db Sql.
+  Module SF := SemFacts.Facts Db.
+  Import RF.
+  Import SF.
+
+(*
+  Module S2 := Sem2 Db.
+  Module S3 := Sem3 Db.
+  Module SQLSem2 := SQLSemantics Db S2 Sql.
+  Module SQLSem3 := SQLSemantics Db S3 Sql.
+*)
+
+  Module RCSem := RcSemantics Db Sem Rc.
+  Module SQLSem := SQLSemantics Db Sem Sql.
+
+  Module Ev := Evl Db.
+
+  Fixpoint undo_bigunion q :=
+    match q with
+    | nil b s => Some ((b, s), List.nil)
+    | union q1 q2 => bind (undo_bigunion q2) (fun r => Some ((fst (fst r), snd (fst r)), q1::snd r))
+    | _ => None
+    end.
+
+  Definition sql_nil s : prequery :=
+    select false (List.map (fun a => (tmnull, a)) s) List.nil cndfalse.
+
+  Fixpoint sql_bigunion b s ql :=
+    match ql with
+    | List.nil => sql_nil s
+    | q::List.nil => q
+    | q::ql0 => qunion b q (sql_bigunion b s ql0)
+    end.
+
+  Definition sql_select b tup ql c :=
+    select b tup ql c.
+
+  Definition sql_distinct T s := selstar true (((T,s)::List.nil)::List.nil) cndtrue.
+
+(*
+  Fixpoint undo_multicomprn q :=
+    match q with
+    | comprn q1 q2 => 
+        bind (undo_multicomprn q1) (fun r => Some (fst r, (fst (snd r), snd (snd r) ++ (q2::List.nil))))
+    | single b tup => Some (b, (tup, List.nil))
+    | _ => None
+    end.
+
+  Definition xlate_ncoll_fix r :=
+    (* FIXME the 0s below are wrong: we need to know the arity of the query *)
+    bind r (fun r' =>
+    let b := fst (fst r') in let s := snd (fst r') in let ql := snd r' in
+    Some (sql_bigunion b s ql)).
+
+  Definition xlate_ndisjunct_fix r :=
+    bind r (fun r' =>
+     let b := fst r' in let tup := fst (snd r') in let ql := snd (snd r') in
+     Some (sql_select b tup ql)).
+
+*)
+
+  Axiom of_precond : precond -> pretm.
+
+  Definition sql_empty q s := cndnot (cndex (selstar false (((tbquery q,s)::List.nil)::List.nil) cndtrue)).
+
+(*
+  Axiom rcschema : Rc.tm -> option Scm.
+  Axiom rcdistinct : Rc.tm -> option bool.
+*)
+
+  (* normal form translation *)
+  Inductive j_base_x (d : Db.D) : list Scm -> Rc.tm -> Sql.pretm -> Prop :=
+  | jbx_cst  : forall g c, j_base_x d g (cst c) (tmconst c)
+  | jbx_null : forall g, j_base_x d g null tmnull
+  | jbx_proj : forall g n x,
+      (* the assumption on well-formedness wrt the context can be provided separately *)
+      (* List.nth_error g n = Some s -> j_var x s -> *)
+      j_base_x d g (proj (var n) x) (tmvar (n,x)).
+
+  Inductive j_basel_x (d : Db.D) : list Scm -> list Rc.tm -> list Sql.pretm -> Prop :=
+  | j_blx_nil : forall g, j_basel_x d g List.nil List.nil
+  | j_blx_cons : forall g t tml,
+      forall t' tml',
+      j_base_x d g t t' ->
+      j_basel_x d g tml tml' ->
+      j_basel_x d g (t::tml) (t'::tml').
+
+  Inductive j_tuple_x (d : Db.D) : list Scm -> Rc.tm -> Scm -> list Sql.pretm -> Prop :=
+  | jtx_mktup : forall g bl, 
+      forall tl',
+(*      List.NoDup (List.map fst bl) -> *)
+      j_basel_x d g (List.map snd bl) tl' ->
+      j_tuple_x d g (mktup bl) (List.map fst bl) tl'.
+
+  Inductive j_cond_x (d : Db.D) : list Scm -> Rc.tm -> Sql.precond -> Prop :=
+  | jbx_empty : forall g q b,
+      forall q' s,
+      j_coll_x d g q b s q' 
+      -> j_cond_x d g (empty b q) (sql_empty q' s)
+  | jwx_pred : forall g n p tl,
+      forall tl',
+      j_basel_x d g tl tl' -> length tl = n ->
+      j_cond_x d g (pred n p tl) (cndpred n p tl')
+
+  with j_coll_x (d : Db.D) : list Scm -> Rc.tm -> bool -> Scm -> Sql.prequery -> Prop :=
+  | jcx_nil : forall g b s, 
+      j_coll_x d g (nil b s) b s (sql_nil s)
+  | jcx_disjunct : forall g t,
+      forall b s tl' c' Bl',
+      (* not union is implicity in j_disjunct_x *)
+      j_disjunct_x d g t b s tl' c' Bl'  ->
+      j_coll_x d g t b s (sql_select b (List.combine tl' s) Bl' c')
+  | jcx_union : forall g t1 t2,
+      forall b s tl1' c' Bl1' q2' ,
+      j_disjunct_x d g t1 b s tl1' c' Bl1' ->
+      j_coll_x d g t2 b s q2' ->
+      j_coll_x d g (union t1 t2) b s (qunion (negb b) (sql_select b (List.combine tl1' s) Bl1' c') q2')
+
+  with j_disjunct_x (d : Db.D) : list Scm -> Rc.tm -> bool -> Scm -> list Sql.pretm -> Sql.precond -> list (list (Sql.pretb * Scm)) -> Prop :=
+  | jdx_single : forall g b tup c,
+      forall s tl' c',
+      j_tuple_x d g tup s tl' -> j_cond_x d g c c' ->
+      j_disjunct_x d g (cwhere (single b tup) c) b s tl' c' List.nil
+  | jdx_comprn : forall g q1 q2,
+      forall b s s2 tl1' c' Bl1' T2',
+      j_gen_x d g q2 b s2 T2' ->
+      j_disjunct_x d (s2::g) q1 b s tl1' c' Bl1' ->
+      j_disjunct_x d g (comprn q1 q2) b s tl1' c' (((T2', s2)::List.nil) :: Bl1')
+
+  with j_gen_x (d : Db.D) : list Scm -> Rc.tm -> bool -> Scm -> Sql.pretb -> Prop :=
+  | jgx_tab : forall g x,
+      forall s, Db.db_schema d x = Some s ->
+      j_gen_x d g (tab x) false s (tbbase x)
+  | jgx_diff : forall g q1 q2,
+      forall s q1' q2',
+      j_coll_x d g q1 false s q1' ->
+      j_coll_x d g q2 false s q2' ->
+      j_gen_x d g (diff q1 q2) false s (tbquery (qexcept true q1' q2'))
+  | jgx_dtab : forall g x,
+      forall s, Db.db_schema d x = Some s ->
+      j_gen_x d g (dist (tab x)) true s (tbquery (sql_distinct (tbbase x) s))
+  | jgx_ddiff : forall g q1 q2,
+      forall s q1' q2',
+      j_coll_x d g q1 false s q1' ->
+      j_coll_x d g q2 false s q2' ->
+      j_gen_x d g (dist (diff q1 q2)) true s (tbquery (sql_distinct (tbquery (qexcept true q1' q2')) s))
+  | jgx_prom : forall g q,
+      forall s q',
+      j_coll_x d g q true s q' -> 
+      j_gen_x d g (prom q) false s (tbquery q')
+  .
+
+  Derive Inversion jbx_proj_inv with (forall d g n x t', j_base_x d g (proj (var n) x) t') Sort Prop.
+  Derive Inversion jbx_empty_inv with (forall d g b q t', j_base_x d g (empty b q) t') Sort Prop.
+  Derive Inversion jblx_nil_inv with (forall d g tml', j_basel_x d g List.nil tml') Sort Prop.
+  Derive Inversion jblx_cons_inv with (forall d g t tml tml', j_basel_x d g (t::tml) tml') Sort Prop.
+  Derive Inversion jtx_mktup_inv with (forall d g bl s tml', j_tuple_x d g (mktup bl) s tml') Sort Prop.
+  Derive Inversion jwx_pred_inv with (forall d g n p tl c, j_cond_x d g (pred n p tl) c) Sort Prop.
+  Derive Inversion jcx_nil_inv with (forall d g b s b' s' q', j_coll_x d g (nil b s) b' s' q') Sort Prop.
+  (* Derive Inversion jcx_disjunct_inv we should know that j_disjunct_x holds and invert that one *)
+  Derive Inversion jcx_union_inv with (forall d g t1 t2 b s q', j_coll_x d g (union t1 t2) b s q') Sort Prop.
+  Derive Inversion jdx_single_inv with (forall d g b tup c b' s' tl' c' Bl', j_disjunct_x d g (cwhere (single b tup) c) b' s' tl' c' Bl') Sort Prop.
+  Derive Inversion jdx_comprn_inv with (forall d g t1 t2 b s tl' c' Bl', j_disjunct_x d g (comprn t1 t2) b s tl' c' Bl') Sort Prop.
+  Derive Inversion jgx_tab_inv with (forall d g x b s T', j_gen_x d g (tab x) b s T') Sort Prop.
+  Derive Inversion jgx_diff_inv with (forall d g t1 t2 b s T', j_gen_x d g (diff t1 t2) b s T') Sort Prop.
+  Derive Inversion jgx_dtab_inv with (forall d g x b s T', j_gen_x d g (dist (tab x)) b s T') Sort Prop.
+  Derive Inversion jgx_ddiff_inv with (forall d g t1 t2 b s T', j_gen_x d g (dist (diff t1 t2)) b s T') Sort Prop.
+  Derive Inversion jgx_prom_inv with (forall d g t b s T', j_gen_x d g (prom t) b s T') Sort Prop.
+
+  Scheme jwx_ind_mut   := Induction for j_cond_x      Sort Prop
+  with   jcx_ind_mut   := Induction for j_coll_x      Sort Prop
+  with   jdx_ind_mut   := Induction for j_disjunct_x  Sort Prop
+  with   jgx_ind_mut   := Induction for j_gen_x       Sort Prop.
+
+  Combined Scheme j_x_ind_mut from jwx_ind_mut, jcx_ind_mut, jdx_ind_mut, jgx_ind_mut.
+
+  Lemma j_basel_x_length : forall d G tl tl', j_basel_x d G tl tl' -> length tl = length tl'.
+  Proof.
+    intros d G tl tl' H. induction H; simpl; intuition.
+  Qed.
+
+  Lemma j_tuple_x_length : forall d G t s tl', j_tuple_x d G t s tl' -> length s = length tl'.
+  Proof.
+    intros d G t s tl' H. inversion H; simpl; subst.
+    generalize (j_basel_x_length _ _ _ _ H0). do 2 rewrite map_length. intuition.
+  Qed.
+
+  Lemma j_disjunct_x_length : forall d G t b s tl c Bl,
+    j_disjunct_x d G t b s tl c Bl ->
+    List.length s = List.length tl.
+  Proof.
+    intros d G t b s qt c Bl H.
+    eapply (jdx_ind_mut _
+          (fun G0 t0 t0' _ => True)
+          (fun G0 t0 b0 s0 q0 _ => True)
+          (fun G0 t0 b0 s0 tml0 _ Bl0 _ => length s0 = length tml0)
+          (fun G0 t0 b0 s0 T' _ => True)
+          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H).
+    Unshelve.
+    all: simpl; intuition.
+    eapply j_tuple_x_length. exact j.
+  Qed.
+
+  Lemma j_tuple_x_sem_eq : forall d G t s tml',
+    j_tuple_x d G t s tml' ->
+    forall s' St, RCSem.j_tuple_sem d G t s' St -> s = s'.
+  Proof.
+    intros d G t s tml' H. inversion H; subst.
+    intros s' St H'. inversion H'; subst.
+    apply map_fst_combine. exact H5.
+  Qed.
+
+  Lemma j_coll_x_sem_eq : forall d G t b s qt,
+    j_coll_x d G t b s qt ->
+    forall b' s' St, RCSem.j_coll_sem d G t b' s' St ->
+    b = b' /\ s = s'.
+  Proof.
+    intros d G t b s qt Hx.
+    eapply (jcx_ind_mut _
+          (fun G0 t0 t0' _ => True)
+          (fun G0 t0 b0 s0 q0 _ => forall b' s' St, RCSem.j_coll_sem d G0 t0 b' s' St -> b0 = b' /\ s0 = s')
+          (fun G0 t0 b0 s0 tml0 _ Bl0 _ => forall b' s' St, RCSem.j_disjunct_sem d G0 t0 b' s' St -> b0 = b' /\ s0 = s')
+          (fun G0 t0 b0 s0 T' _ => forall b' s' St, RCSem.j_gen_sem d G0 t0 b' s' St -> b0 = b' /\ s0 = s')
+          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ Hx).
+    Unshelve.
+    + simpl; intuition.
+    + simpl; intuition.
+    + simpl; intros g0 b0 s0 b' s' St Hsem. inversion Hsem; subst. intuition. inversion H4.
+    + simpl. intros g0 t0 b0 s0 tml' c' Bl' Ht0 IHt0 b' s' St Hsem. inversion Hsem; subst; inversion Ht0; subst.
+      eapply IHt0. exact H4.
+      eapply IHt0. exact H4.
+    + simpl. intros g0 t1 t2 b0 s0 tml' c' Bl1' q2' Ht1 IHt1 Ht2 IHt2 b' s' St Hsem. inversion Hsem; subst.
+      inversion H4.
+      eapply IHt2. exact H7.
+    + simpl. intros g0 b0 t0 c0 s0 tml' c' Ht0 Hc' _ b' s' St Hsem. inversion Hsem; subst; intuition.
+      eapply j_tuple_x_sem_eq. exact Ht0. exact H5.
+    + simpl. intros G0 q1 q2 b0 s0 s1 tl1' c' Bl1' T2' Hq2 IHq2 Hq1 IHq1 b' s' St Hsem. inversion Hsem; subst.
+      destruct (IHq2 _ _ _ H5); subst. intuition.
+      destruct (IHq1 _ _ _ H6); subst. reflexivity.
+    + simpl. intros G0 x s0 Hs0 b' s' St Hsem. inversion Hsem; subst. clear H4.
+      rewrite Hs0 in e; injection e; intuition.
+    + simpl. intros G0 q1 q2 s0 q1' q2' Hq1 IHq1 Hq2 IHq2 b' s' St Hsem. inversion Hsem; subst.
+      destruct (IHq1 _ _ _ H5); intuition.
+    + simpl. intros G0 x s0 Hs0 b' s' St Hsem. inversion Hsem; subst. clear H4.
+      rewrite Hs0 in e; injection e; intuition.
+    + simpl. intros G0 q1 q2 s0 q1' q2' Hq1 IHq1 Hq2 IHq2 b' s' St Hsem. inversion Hsem; subst.
+      destruct (IHq1 _ _ _ H5); intuition.
+    + simpl. intros G0 q s0 q' Hq IHq b' s' St Hsem. inversion Hsem; subst.
+      destruct (IHq _ _ _ H4). intuition.
+  Qed.
+
+  Lemma j_coll_x_sem_eq_bool : forall d G t b s qt b' s' St,
+    j_coll_x d G t b s qt -> RCSem.j_coll_sem d G t b' s' St ->
+    b = b'.
+  Proof.
+    intros. destruct (j_coll_x_sem_eq _ _ _ _ _ _ H _ _ _ H0). intuition.
+  Qed.
+
+  Lemma j_coll_x_sem_eq_scm : forall d G t b s qt b' s' St,
+    j_coll_x d G t b s qt -> RCSem.j_coll_sem d G t b' s' St ->
+    s = s'.
+  Proof.
+    intros. destruct (j_coll_x_sem_eq _ _ _ _ _ _ H _ _ _ H0). intuition.
+  Qed.
+
+  Lemma base_rcsem_to_sqlsem : forall d G t St,
+    RCSem.j_base_sem d G t St ->
+    forall t', j_base_x d G t t' ->
+    exists St', SQLSem.j_tm_sem G t' St' /\ forall h, St' h ~= St h.
+  Proof.
+  intros d G t St H. elim H; simpl.
+  + intros G0 c t' j; clear H. inversion j; subst.
+    eexists; split. constructor. simpl; reflexivity.
+  + intros G0 t' j; clear H. inversion j; subst.
+    eexists; split. constructor. simpl; reflexivity.
+  + intros G0 i a Sia j. clear H; intros t0' H.
+    inversion H; subst. elim j; intros.
+    - eexists; split. constructor. constructor. 
+      (* XXX exact H0. doesn't work -- apparently here Coq doesn't know that RC and SQL use the same Eval *)
+      admit.
+      simpl; intro. (* this will actually be reflexivity after we fix the problem above *) admit.
+    - decompose record H1; rename x into Sp.
+      eexists; split. constructor. constructor.
+      (* XXX exact H0. doesn't work -- apparently here Coq doesn't know that RC and SQL use the same Eval *)
+      admit.
+      simpl; intro. (* this will actually be reflexivity after we fix the problem above *) admit.
+    Unshelve. (* will go away after metavariables are instantiated *) admit. admit.
+  Admitted.
+
+  Lemma basel_rcsem_to_sqlsem : forall d G tl Stl,
+    RCSem.j_basel_sem d G tl Stl ->
+    forall tl', j_basel_x d G tl tl' ->
+    exists Stl', SQLSem.j_tml_sem G tl' Stl' /\ forall h, Stl' h ~= Stl h.
+  Proof.
+    intros d G tl Stl H. elim H; simpl.
+    + intros G0. clear H; intros tml0' H.
+      inversion H; subst. eexists; split. constructor. simpl; intro. reflexivity.
+    + intros G0 t0 tml0 St0 Stml0 jt0 jtml0 IHtml0. clear H; intros tml0' H.
+      inversion H; subst. decompose record (base_rcsem_to_sqlsem _ _ _ _ jt0 _ H3); rename x into St'.
+      decompose record (IHtml0 _ H5); rename x into Stml'.
+      eexists; split. constructor. exact H1. exact H4.
+      simpl; intro.
+      (* rewrite H2, H6. up to JMeq reasoning *) admit.
+  Admitted.
+
+  Lemma tuple_rcsem_to_sqlsem : forall d G t s St,
+    RCSem.j_tuple_sem d G t s St ->
+    forall tml', j_tuple_x d G t s tml' ->
+      exists Stml', SQLSem.j_tml_sem G tml' Stml' /\ forall h, Stml' h ~= St h.
+  Proof.
+    intros d G t s St H. inversion H; subst.
+    intros tml' Html'. inversion Html'; subst.
+    enough (List.map snd (combine s bl) = bl). rewrite H3 in H5.
+    decompose record (basel_rcsem_to_sqlsem _ _ _ _ H6 _ H5); rename x into Stml'.
+    eexists; split. exact H8.
+    (* by JMeq transitivity, dependent equational reasoning using e and H9 and H0, where the equality is expressed using sigma types... *) admit.
+    apply map_snd_combine. exact H2.
+  Admitted.
+
+  Theorem rcsem_to_sqlsem : forall d G t b s St,
+    RCSem.j_coll_sem d G t b s St ->
+    forall qt, j_coll_x d G t b s qt ->
+    exists Sqt, SQLSem.j_q_sem d G s qt Sqt /\ forall h, Sqt h ~= St h.
+  Proof.
+    intros d G t b s St H.
+    eapply (RCSem.jcs_ind_mut _
+          (fun G0 t0 S0 _ => forall ct0, j_cond_x d G0 t0 ct0 ->
+            exists Sct0, SQLSem.j_cond_sem d G0 ct0 Sct0 /\ forall h, Sct0 h ~= S0 h)
+          (fun G0 t0 b0 s0 S0 _ => forall qt0, j_coll_x d G0 t0 b0 s0 qt0 ->
+            exists Sqt0, SQLSem.j_q_sem d G0 s0 qt0 Sqt0 /\ forall h, Sqt0 h ~= S0 h)
+          (fun G0 t0 b0 s0 S0 _ => forall tml0' c0' Bl0', j_disjunct_x d G0 t0 b0 s0 tml0' c0' Bl0' -> 
+            exists G1 Stml0' Sc0' SBl0',
+              SQLSem.j_tml_sem (G1 ++ G0) tml0' Stml0' /\ SQLSem.j_cond_sem d (G1 ++ G0) c0' Sc0'
+              /\ SQLSem.j_btbl_sem d G0 G1 Bl0' SBl0'
+              /\ forall h, 
+                  (let S1 := SBl0' h in
+                  let p  := fun Vl => Sem.is_btrue (Sc0' (Ev.env_app _ _ (Ev.env_of_tuple G1 Vl) h)) in
+                  let S2 := Rel.sel S1 p in
+                  let f  := fun Vl => Stml0' (Ev.env_app _ _ (Ev.env_of_tuple G1 Vl) h) in
+                  let S := Rel.sum S2 f
+                  in if b0 then Rel.flat S else S)
+                  ~= S0 h)
+(*
+            exists Sqt0, SQLSem2.j_q_sem d G0 s0 (sql_select b0 (List.combine tml0' s0) Bl0') Sqt0
+              /\ forall h, Sqt0 h ~= S0 h)
+*)
+          (fun G0 t0 b0 s0 S0 _ => forall st0 Tt0, j_gen_x d G0 t0 b0 st0 Tt0 ->
+            s0 = st0 /\
+            exists STt0, SQLSem.j_tb_sem d G0 s0 Tt0 STt0
+              /\ forall h, STt0 h ~= S0 h)
+          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H).
+  Unshelve.
+  (*-- mutual induction cases: base --*)
+  + simpl. intros G0 q0 b0 s0 Sq0 Hq0 IHq0. clear H; intros ct0 H.
+    inversion H; subst.
+    destruct (j_coll_x_sem_eq _ _ _ _ _ _ H4 _ _ _ Hq0); subst.
+    decompose record (IHq0 _ H4). rename x into Sq'.
+    eexists; split. constructor. constructor. constructor. constructor. constructor. constructor. exact H2.
+    constructor. reflexivity. constructor. constructor.
+    simpl.
+    (* TODO: calculations with dependent types *) admit. 
+    (* the following will go away *)
+    Unshelve. admit. admit.
+  + simpl. intros G0 n0 p0 tml0 Stml0 Hlen Html0. clear H; intros ct0 H.
+    inversion H; subst.
+    decompose record (basel_rcsem_to_sqlsem _ _ _ _ Html0 _ H5). rename x into Stl'.
+    eexists; split. constructor. exact H2.
+    simpl; intro.
+    (* TODO: equational reasoning with dep types *)
+    admit.
+    (* the following will go away *)
+    Unshelve. admit.
+  (*-- mutual induction cases: collection --*)
+  + simpl; intros G0 b0 s0. simpl. clear H; intros qt0 H.
+    eapply (jcx_nil_inv _ _ _ _ _ _ _ 
+             (fun dd GG bb ss bb' ss' qq' =>
+               exists Sqt0, SQLSem.j_q_sem d GG ss' qq' Sqt0 /\
+               forall h, Sqt0 h ~= RCSem.sem_nil (length ss'))
+               _ _ H). Unshelve.
+    - simpl; intros; subst; clear H4 H5.
+      (* XXX: we need to factor out the proof that the semantics of sql_nil is the same as RCSem.sem_nil *)
+      admit.
+    - simpl; intros; subst. inversion H1.
+  + simpl; intros G0 t0 b0 s0 St0 jt0 IHt0. clear H; intros qt0 H.
+    inversion H; subst.
+    - inversion jt0.
+    - decompose record (IHt0 _ _ _ H0); rename x into G1; rename x0 into Stl'; rename x1 into SBl'.
+      enough (exists Stl'', SQLSem.j_tml_sem (G1 ++ G0) (List.map fst (List.combine tl' s0)) Stl'').
+      decompose record H4; rename x into Stml''. eexists; split. constructor.
+      * exact H3.
+      * exact H2.
+      * exact H6.
+      * symmetry; eapply map_snd_combine. symmetry; apply (j_disjunct_x_length _ _ _ _ _ _ _ _ H0).
+      * intro. rewrite <- H5. simpl. (* reasoning on terms that depend on equations *) admit.
+      * replace (List.map fst (combine tl' s0)) with tl'. eexists; exact H1.
+        symmetry; apply map_fst_combine. symmetry; apply (j_disjunct_x_length _ _ _ _ _ _ _ _ H0).
+        Unshelve.
+        generalize (j_disjunct_x_length _ _ _ _ _ _ _ _ H0); intro Hlen.
+        erewrite map_fst_combine. rewrite Hlen; reflexivity. rewrite Hlen; reflexivity.
+    - inversion jt0.
+  + simpl; intros G0 t1 t2 b0 s0 St1 St2 jt1 IHt1 jt2 IHt2. clear H; intros qt0 H.
+    eapply (jcx_union_inv _ _ _ _ _ _ _
+             (fun dd GG tt1 tt2 bb ss qq' =>
+               exists Sqt0, SQLSem.j_q_sem d G0 ss qq' Sqt0 /\
+               forall h, Sqt0 h ~= (if b0 then Rel.flat (Rel.plus (St1 h) (St2 h)) else Rel.plus (St1 h) (St2 h)))
+             _ _ H). Unshelve.
+    - simpl; intros; subst. inversion H1.
+    - simpl; intros; subst; clear H0.
+      decompose record (IHt2 _ H7); clear IHt2; rename x into Sq2'.
+      decompose record (IHt1 _ _ _ H3); clear IHt1. 
+      rename x into G1; rename x0 into Stl1'; rename x1 into Sc'; rename x2 into SBl1'.
+      enough (exists Stl1'', SQLSem.j_tml_sem (G1 ++ G0) (List.map fst (combine tl1' s0)) Stl1'').
+      decompose record H6; clear H6; rename x into Stl1''.
+      eexists. split. constructor. constructor.
+      exact H5. exact H4. exact H9.
+      symmetry. apply map_snd_combine. symmetry. apply (j_disjunct_x_length _ _ _ _ _ _ _ _ H3).
+      exact H1.
+      intro.
+      (* here the rewriting is blocked by the presence of an admit-related metavariable, which will go away,
+         but there's also some reasoning on equastions and casts that must disappear.
+         We also need to use a rewrite <- H6, and a destruct b0 because of the test on (negb b0) *)
+      admit.
+      replace (List.map fst (combine tl1' s0)) with tl1'. eexists; exact H0.
+      symmetry. apply map_fst_combine. symmetry. apply (j_disjunct_x_length _ _ _ _ _ _ _ _ H3).
+      Unshelve.
+      generalize (j_disjunct_x_length _ _ _ _ _ _ _ _ H3); intro Hlen.
+      erewrite map_fst_combine. rewrite Hlen; reflexivity. rewrite Hlen; reflexivity.
+  (*-- mutual induction cases: disjunct --*)
+  + simpl; intros G0 b0 tup c stup Stup Sc jtup jc IHc. clear H; intros tml0' c0' Bl0' H.
+    inversion H; simpl; subst. clear H3.
+    decompose record (tuple_rcsem_to_sqlsem _ _ _ _ _ jtup _ H9). rename x into Stml0'.
+    decompose record (IHc _ H10). rename x into Sc0'.
+    exists List.nil. eexists. eexists. eexists. split. exact H1.
+    split. exact H3.
+    split. constructor.
+    (* factorize the else branch, and prove it's equivalent to a singleton;
+       then prove flat is invariant on singletons
+
+       BUT ACTUALLY we should expect this point will include a where condition (see note A)!
+       so for the moment let's _not_ consider it
+     *)
+    admit.
+  + simpl; intros G0 q1 q2 b0 sq2 Sq2 sq1 Sq1 e jq2 IHq2 jq1 IHq1. clear H; intros tml0' c0' Bl0' H.
+    inversion H; subst.
+    simpl; intros; subst. decompose record (IHq2 _ _ H3); rename x into ST2'; subst.
+    decompose record (IHq1 _ _ _ H9); rename x into G1; rename x0 into Stml0'; rename x1 into Sc0'; rename x2 into SBl1'.
+    enough (exists Stml0'', SQLSem.j_tml_sem ((G1 ++ (s2 :: List.nil)) ++ G0) tml0' Stml0'').
+    decompose record H6; rename x into Stml0''.
+    enough (exists Sc0'', SQLSem.j_cond_sem d ((G1 ++ (s2 :: List.nil)) ++ G0) c0' Sc0'').
+    decompose record H10; rename x into Sc0''.
+    eexists; eexists; eexists; eexists. split. exact H8.
+    split. exact H11.
+    split. constructor. constructor. exact H1. constructor. reflexivity. exact H5.
+    simpl; intros; subst. (* XXX: proving the equality here will be involved! (B) *)
+    admit.
+    rewrite <- app_assoc; eexists; exact H2.
+    rewrite <- app_assoc; eexists; exact H0.
+    Unshelve.
+    f_equal. do 3 rewrite <- length_concat_list_sum. rewrite concat_app. rewrite app_length. omega.
+    reflexivity.
+  (*-- mutual induction cases: gen --*)
+  + simpl; intros G0 x0 s0 e0. clear H; intros st0 Tt0 Hx0.
+    inversion Hx0; subst. rewrite e0 in H1. injection H1; intuition.
+    eexists; split. constructor. Unshelve. 
+    intro; reflexivity.
+  + simpl; intros G0 t0 s0 St0 jt0 IHt0. clear H; intros st0 Tt0 Ht0.
+    inversion Ht0; subst. enough (s0 = st0). subst. decompose record (IHt0 _ H1); subst; rename x into Sq'.
+    intuition. eexists; split. constructor; exact H0. exact H2.
+    rewrite (j_coll_x_sem_eq_scm _ _ _ _ _ _ _ _ _ H1 jt0); reflexivity.
+  + simpl; intros G0 t1 t2 s0 St1 St2 jt1 IHt1 jt2 IHt2. clear H. intros st0 Tt0 H.
+    inversion H; subst. enough (s0 = st0). subst.
+    decompose record (IHt1 _ H3). decompose record (IHt2 _ H4). rename x into Sq1'; rename x0 into Sq2'.
+    intuition. eexists; split. constructor. constructor. exact H1. exact H5.
+    simpl; intro. rewrite H2, H6. reflexivity.
+    rewrite (j_coll_x_sem_eq_scm _ _ _ _ _ _ _ _ _ H3 jt1); reflexivity.
+  + simpl; intros G0 x0 s0 e0. clear H; intros st0 Tt0 Hx0.
+    inversion Hx0; subst. rewrite e0 in H1. injection H1; intuition.
+    generalize e0; clear e0; rewrite H; intro.
+    eexists; split. constructor. constructor. constructor. constructor.
+    - constructor.
+    - constructor.
+    - shelve.
+    - constructor.
+    - constructor.
+    - (* XXX: semantics of: s::G |- tmlist(s) = environment projection -- do we have the proof? (13) *)
+      admit.
+    - simpl. rewrite app_nil_r. reflexivity.
+    - simpl.
+      (* a rather convoluted equational reasoning: perhaps we can factorize it
+         it probably boils down to proving some eta-equality for sum *)
+      admit.
+    (* these will go away by themselves *)
+    Unshelve.
+    admit. admit. admit. admit. admit. admit. admit.
+  + simpl; intros G0 t1 t2 s0 St1 St2 jt1 IHt1 jt2 IHt2. clear H. intros st0 Tt0 H.
+    inversion H; subst. enough (s0 = st0). subst.
+    decompose record (IHt1 _ H3). decompose record (IHt2 _ H4). rename x into Sq1'; rename x0 into Sq2'.
+    intuition. 
+    eexists; split. constructor. constructor. constructor. constructor. constructor. constructor.
+    - exact H1.
+    - exact H5.
+    - constructor.
+    - reflexivity.
+    - constructor.
+    - constructor.
+    - (* XXX: semantics of: s::G |- tmlist(s) = environment projection -- do we have the proof? (13) *)
+      admit.
+    - simpl; rewrite app_nil_r; reflexivity.
+    - simpl.
+      (* a rather convoluted equational reasoning: perhaps we can factorize it *)
+      admit.
+    - rewrite (j_coll_x_sem_eq_scm _ _ _ _ _ _ _ _ _ H3 jt1); reflexivity.
+    (* these will go away by themselves *)
+    Unshelve.
+    admit. admit. admit. admit.
+  Admitted.
+
+  Lemma tml_sem_tmlist_of_ctx s G :
+    forall s0 Stml,
+      SQLSem.j_tml_sem ((s0++s)::G) (tmlist_of_ctx (s::List.nil)) Stml ->
+        Stml ~= fun h => Ev.tuple_of_env (s::List.nil) (Ev.env_skip (@Ev.subenv1 ((s0 ++ s)::List.nil) G h)).
+  Proof.
+    elim s.
+    + simpl. unfold tmlist_of_ctx. simpl. intros.
+      eapply (SQLSem.j_tml_nil_sem _ _ (fun _ _ => _) _ H). Unshelve.
+      simpl. intros _ Heq. eapply (existT_eq_elim Heq); clear Heq; intros _ Heq.
+      symmetry. eapply (JMeq_trans _ Heq). Unshelve.
+      apply funext_JMeq. reflexivity. reflexivity.
+      intros h1 h2 Hh; subst.
+      eapply (Vector.case0 (fun x => x ~= _)). reflexivity.
+    + simpl. unfold tmlist_of_ctx. simpl. intros.
+      eapply (SQLSem.j_tml_cons_sem _ _ _ _ (fun _ _ _ _ => _ ~= _) _ H0). Unshelve.
+      simpl; intros; subst. eapply (existT_eq_elim H6); clear H6; intros _ H6.
+      symmetry. eapply (JMeq_trans _ H6). Unshelve.
+      apply funext_JMeq. reflexivity. simpl. f_equal; f_equal. rewrite app_length. rewrite map_length. reflexivity.
+      intros h1 h2 Hh; subst.
+      inversion H2. subst.
+      enough (Ev.j_fvar_sem ((s0 ++ a :: l) :: G) 0 a St) as H7'.
+      generalize (Ev.j_fvar_sem_inside _ _ _ _ _ H7'). intro Ht.
+      (* Ht is what we need for the hd *)
+      enough (exists Stml', SQLSem.j_tml_sem (((s0 ++ a :: List.nil) ++ l)::G) (List.map (fun x => tmvar (0,x)) l ++ List.nil) Stml' /\ Stml' ~= Stml0).
+      decompose record H3. rename x into Stml'; clear H3.
+      generalize (H _ _ H6). intro Html.
+      rewrite (Vector.eta (Ev.tuple_of_env _ (Ev.env_skip (@Ev.subenv1 ((s0++a::l)::List.nil) _ h2)))).
+      apply cons_equal.
+      - rewrite Ht. (* can't look into tuple_of_env *) admit.
+      - rewrite app_length. rewrite map_length. reflexivity.
+      - rewrite (Ev.tl_tuple_of_env a l List.nil _).
+        enough (exists (h : Ev.env (((s0 ++ a :: List.nil) ++ l) :: G)), h ~= h2).
+        decompose record H3; clear H3; rename x into h.
+        apply (@JMeq_trans _ _ _ _ (Stml' h)).
+        apply (@JMeq_trans _ _ _ _ 
+          (Ev.tuple_of_env (l::List.nil) (Ev.env_skip (@Ev.subenv1 (((s0 ++ a :: List.nil)++l)::List.nil) _ h)))).
+        apply (f_JMeq _ _ (Ev.tuple_of_env (l::List.nil))). apply JMeq_eq.
+        rewrite <- Ev.env_skip_single. symmetry. apply Ev.env_skip_skip.
+        eapply (f_JMequal (@Ev.subenv1 (((s0++a::List.nil)++l)::List.nil) G) (@Ev.subenv1 ((s0++a::l)::List.nil) G)).
+        simpl. rewrite <- app_assoc. reflexivity. exact H5.
+        erewrite (f_JMequal _ _ h h Html JMeq_refl). reflexivity.
+        eapply (f_JMequal Stml' Stml0 h h2 H8 H5).
+        rewrite <- app_assoc. exists h2. reflexivity.
+        Unshelve.
+        rewrite <- app_assoc. reflexivity.
+        rewrite <- app_assoc. reflexivity.
+        rewrite <- app_assoc. reflexivity.
+        rewrite <- app_assoc. (* some problems because SQLSem.Ev doesn't match Ev *) admit.
+        rewrite <- app_assoc. reflexivity.
+        rewrite <- app_assoc. reflexivity.
+      - rewrite <- app_assoc. eexists. split. exact H4. reflexivity.
+      - (* it's just Hseven *) admit.
+  Admitted.
+
+
+End RcToSql.
+
+(*
+BIGGIES
+-------
+
+A) add where conditions to comprehensions in RC
+
+B) the comprehension case appears to be involved!
+
+
+MEDIUM
+------
+
+Implement rsum
+Convoluted equational reasonings in some cases like dist.
+
+
+SMALLISH
+--------
+
+5) semantics of complex SQL terms
+
+12) factorizing the semantics of sql_distinct is a good idea!
+
+13) do we have the proof that [| s::G |- tmlist(s) |] is an env (s::G) -> env [s] projection?
+
+
+
+TRAINING
+--------
+
+revise working with dep types, JMeq and casts
+
+*)

--- a/RelFacts.v
+++ b/RelFacts.v
@@ -1,4 +1,6 @@
-Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq 
+(* if we do not remove the dependency on Syntax, we can't compile this until we fix syntax *)
+
+Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq Common Syntax
   FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Syntax AbstractRelation Util.
 
 Module Facts (Db : DB) (Sql : SQL Db).

--- a/RelFacts.v
+++ b/RelFacts.v
@@ -3,7 +3,7 @@
 Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq Common Syntax
   FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Syntax AbstractRelation Util.
 
-Module Facts (Db : DB) (Sql : SQL Db).
+Module Facts (Sql : SQL).
 
   Import Db.
   Import Sql.

--- a/RelFacts.v
+++ b/RelFacts.v
@@ -148,6 +148,7 @@ Module Facts (Sql : SQL).
             apply Rel.T_eqb_eq. reflexivity.
         * apply Rel.p_fs. exact H0.
     + intros. apply Rel.T_eqb_eq. reflexivity.
+
     + intros. apply Rel.T_eqb_eq. reflexivity.
   Qed.
 
@@ -331,9 +332,25 @@ Module Facts (Sql : SQL).
     + extensionality v'. rewrite H0. reflexivity.
   Qed.
 
-  Axiom rsum_id : forall m n (f : Rel.T m -> Rel.R n) r,
+  Lemma rsum_id : forall m n (f : Rel.T m -> Rel.R n) r,
+     m = n ->
      (forall x, f x ~= Rel.Rsingle x) ->
      Rel.rsum r f ~= r.
+  Proof.
+    intros. enough (exists (g : Rel.T m -> Rel.T n), forall x, g x ~= x).
+    decompose record H1. rename x into g; rename H2 into Hg. clear H1.
+    eapply (trans_JMeq _ (sum_id _ _ _ _ H Hg)). Unshelve.
+      subst. exists (fun x => x); intuition.
+    apply eq_JMeq; apply Rel.p_ext. intro.
+    rewrite Rel.p_rsum. rewrite Rel.p_sum.
+    induction (Rel.supp r); intuition.
+    simpl. subst. rewrite H0, Hg, IHl.
+    destruct (Rel.T_dec _ a t).
+    + rewrite e, (proj2 (Rel.T_eqb_eq _ _ _) eq_refl), Rel.p_single. simpl. omega.
+    + enough (Rel.T_eqb a t = false). rewrite H, Rel.p_single_neq. omega.
+      exact n0. destruct (Rel.T_eqb a t) eqn:e. contradiction n0. apply (proj1 (Rel.T_eqb_eq _ _ _)). exact e.
+      reflexivity.
+  Qed.
 
   Lemma Rel_Rone_times n (r : Rel.R n) : Rel.times Rel.Rone r ~= r.
   Proof.
@@ -347,42 +364,394 @@ Module Facts (Sql : SQL).
   Qed.
 
   (* maybe derive from another result: R_sum r (fun Vl => R_single x) = R.sum r (fun Vl => x). *)
-  Axiom rsum_single : forall n (r : Rel.R n), Rel.rsum r (fun Vl => Rel.Rsingle Vl) ~= r.
+  Lemma rsum_single : forall n (r : Rel.R n), Rel.rsum r (fun Vl => Rel.Rsingle Vl) ~= r.
+  Proof.
+    intros. apply rsum_id; intuition.
+  Qed.
+
+(*
+  Lemma memb_sum_tech_r {m} {n} (R : Rel.R m) (f : Rel.T m -> Rel.T n) x l1 : 
+    NoDup l1 -> forall l2, incl l2 (Rel.supp R) -> NoDup l2 -> 
+    (forall t u, List.In t l1 -> List.In u (Rel.supp R) -> List.In t (Rel.supp (f u)) -> List.In u l2) ->
+    (forall u, List.In u l2 -> List.Incl (Rel.supp (f u)) l1) ->
+    list_sum (List.map (fun t => Rel.memb (Rel.rsum R f) t * Rel.memb (g t) x) l1) 
+    = list_sum (List.map (fun u => Rel.memb R u * Rel.memb (Rel.rsum (f t) g) x) l2).
+  Proof.
+    elim l1.
+    + intros. replace l2 with (@List.nil (Rel.T m)). reflexivity.
+      destruct l2; auto. contradiction (H3 t). left. reflexivity.
+    + intros t l1' IH Hl1' l2 Hsupp Hl2 H1 H2. simpl.
+      replace (list_sum (List.map (Rel.memb R) l2)) with
+        (list_sum (List.map (Rel.memb R) (filter (fun x => Rel.T_eqb (f x) t) l2)) +
+         list_sum (List.map (Rel.memb R) (filter (fun x => negb (Rel.T_eqb (f x) t)) l2))).
+      - f_equal.
+        * rewrite Rel.p_sum. apply (list_sum_ext Nat.eq_dec).
+          generalize (Rel.p_nodup _ R) l2 Hsupp Hl2 H1; clear l2 Hsupp Hl2 H1 H2; elim (Rel.supp R).
+          ++ simpl. intros _ l2 Hincl. replace l2 with (@List.nil (Rel.T m)). reflexivity.
+             destruct l2; auto. contradiction (Hincl t0). left. reflexivity.
+          ++ intros x l3' IHin Hnodup l2 Hincl Hl2 H1 y. simpl. destruct (Rel.T_eqb (f x) t) eqn:Heq; simpl.
+            -- destruct (Nat.eq_dec (Rel.memb R x) y); simpl.
+              ** assert (exists n, count_occ Nat.eq_dec 
+                    (List.map (Rel.memb R) (filter (fun x0 : Rel.T m => Rel.T_eqb (f x0) t) l2)) y = S n).
+                  apply count_occ_In_Sn. rewrite <- e. apply in_map. apply filter_In. split; auto.
+                  eapply H1. left. reflexivity. left. reflexivity. apply Rel.T_eqb_eq. exact Heq.
+                destruct H. rewrite (count_occ_rmone_r _ _ _ _ _ H). f_equal.
+                transitivity (count_occ Nat.eq_dec (List.map (Rel.memb R) 
+                  (filter (fun x1 => Rel.T_eqb (f x1) t) (rmone _ (Rel.T_dec _) x l2))) y).
+                +++ apply IHin.
+                  --- inversion Hnodup. exact H4.
+                  --- eapply incl_rmone; assumption.
+                  --- apply nodup_rmone. exact Hl2.
+                  --- intros. apply in_rmone_neq. 
+                    *** inversion Hnodup. intro. rewrite H8 in H6. contradiction H6.
+                    *** eapply H1. exact H0. right. exact H2. exact H3.
+                +++ apply map_filter_tech. exact Heq. rewrite e. reflexivity. 
+                    eapply H1. left. reflexivity. left. reflexivity. apply Rel.T_eqb_eq. exact Heq.
+              ** replace (count_occ Nat.eq_dec (List.map (Rel.memb R) (filter (fun x0 => Rel.T_eqb (f x0) t) l2)) y)
+                  with (count_occ Nat.eq_dec (List.map (Rel.memb R) (filter (fun x0 => Rel.T_eqb (f x0) t) (rmone _ (Rel.T_dec _) x l2))) y).
+                apply IHin.
+                +++ inversion Hnodup. exact H3.
+                +++ eapply incl_rmone; assumption.
+                +++ apply nodup_rmone. exact Hl2. 
+                +++ intros. apply in_rmone_neq. 
+                  --- inversion Hnodup. intro. rewrite H7 in H5. contradiction H5.
+                  --- eapply H1. exact H. right. exact H0. exact H2.
+                +++ apply count_occ_map_filter_rmone_tech. exact n0.
+            -- replace (count_occ Nat.eq_dec (List.map (Rel.memb R) (filter (fun x0 => Rel.T_eqb (f x0) t) l2)) y)
+                  with (count_occ Nat.eq_dec (List.map (Rel.memb R) (filter (fun x0 => Rel.T_eqb (f x0) t) (rmone _ (Rel.T_dec _) x l2))) y). apply IHin.
+              *** inversion Hnodup. exact H3.
+              *** eapply incl_rmone; assumption.
+              *** apply nodup_rmone. exact Hl2. 
+              *** intros. apply in_rmone_neq. 
+                +++ inversion Hnodup. intro. rewrite H7 in H5. contradiction H5.
+                +++ eapply H1. exact H. right. exact H0. exact H2.
+              *** rewrite filter_rmone_false. reflexivity. exact Heq.
+        * apply IH.
+          ++ inversion Hl1'; assumption.
+          ++ intro x. intro Hx. apply Hsupp. 
+             destruct (proj1 (filter_In (fun x => negb (Rel.T_eqb (f x) t)) x l2) Hx). exact H.
+          ++ apply NoDup_filter. exact Hl2.
+          ++ intros. apply filter_In. split.
+            -- eapply H1. right. exact H. exact H0. exact H3.
+            -- apply Bool.negb_true_iff. destruct (Rel.T_dec _ (f u) t).
+              ** inversion Hl1'. rewrite <- e in H6. rewrite H3 in H6. contradiction H6.
+              ** destruct (Rel.T_eqb (f u) t) eqn:ed; auto. contradiction n0. apply Rel.T_eqb_eq. exact ed.
+          ++ intros. assert (List.In u l2 /\ negb (Rel.T_eqb (f u) t) = true).
+            -- apply (proj1 (filter_In (fun x => negb (Rel.T_eqb (f x) t)) u l2) H).
+            -- destruct H0. assert (f u <> t). intro. 
+              pose (H4' := proj2 (Rel.T_eqb_eq _ (f u) t) H4); clearbody H4'.
+              rewrite H4' in H3. discriminate H3. 
+              pose (H2' := H2 _ H0); clearbody H2'. inversion H2'; auto. contradiction H4. symmetry. exact H5.
+      - elim l2; auto.
+        intros x l2' IHin. simpl. destruct (Rel.T_eqb (f x) t); simpl.
+        * rewrite <- IHin. omega.
+        * rewrite <- IHin. omega.
+  Qed.
+
+*)
+
+  Lemma list_sum_plus {A} (f g : A -> nat) l :
+    list_sum (List.map (fun x => f x + g x) l) = list_sum (List.map f l) + list_sum (List.map g l).
+  Proof.
+    induction l; intuition.
+    simpl. rewrite IHl. omega.
+  Qed.
+
+  Lemma list_sum_times_l {A} n (f : A -> nat) l :
+    list_sum (List.map (fun x => n * f x) l) = n * list_sum (List.map f l).
+  Proof.
+    induction l; intuition.
+    simpl. rewrite IHl. rewrite mult_plus_distr_l. reflexivity.
+  Qed.
+
+  Lemma list_sum_append l1 l2 : list_sum (l1 ++ l2) = list_sum l1 + list_sum l2.
+  Proof.
+    induction l1; simpl; intuition.
+  Qed.
+
+  Lemma NoDup_remove {A} (a:A) l1 l2 : NoDup (l1 ++ a :: l2) -> NoDup (l1 ++ l2).
+  Proof.
+    induction l1; simpl; intros.
+    + inversion H; intuition.
+    + constructor. inversion H. intro; apply H2.
+      apply in_or_app. destruct (in_app_or _ _ _ H4).
+      left; assumption. right; right; assumption.
+      apply IHl1. inversion H. intuition.
+  Qed.
+
+  Lemma rsum_rsum_list_sum {A} (l1 l2 : list A) f:
+    NoDup l1 -> NoDup l2 -> incl l2 l1 ->
+    (forall x, List.In x l1 -> ~ List.In x l2 -> f x = 0) ->
+    list_sum (List.map f l1) = list_sum (List.map f l2).
+  Proof.
+    intros. generalize dependent l1; induction l2.
+    + induction l1; simpl; intuition. rewrite H2. apply IHl1. inversion H; intuition.
+      intro. intro. inversion H3.
+      intros. apply H2; intuition. left. reflexivity.
+      intro. inversion H3.
+    + simpl. intros. enough (List.In a l1). decompose record (in_split _ _ H3). rewrite H5.
+      rewrite map_app, list_sum_append. simpl.
+      rewrite (plus_comm (f a)). rewrite plus_assoc. rewrite <- list_sum_append, <- map_app.
+      rewrite plus_comm. f_equal. apply IHl2.
+      - inversion H0; intuition.
+      - rewrite H5 in H. apply (NoDup_remove _ _ _ H).
+      - enough (forall A (y z : A) la lb lc, List.In y la -> y <> z -> incl la (lb ++ z :: lc) -> List.In y (lb ++ lc)).
+        intro. intro. eapply (H4 _ a0 a). apply H6. inversion H0; intro; subst. contradiction H9.
+        intro. intro. enough (List.In a1 (a::l2)).
+        generalize (H1 _ H8). rewrite H5; intuition.
+        right; exact H7.
+        intros B y z la. induction la; simpl; intros. contradiction H4.
+        destruct H4. subst. enough (List.In y (lb ++ z :: lc)).
+        induction lb in H4 |- *; simpl. simpl in H4. destruct H4; subst; intuition.
+        simpl in H4. destruct H4. intuition. right. apply IHlb. exact H4.
+        apply H7. left; reflexivity.
+        apply IHla. exact H4. exact H6. intro. intro. apply H7. right. exact H8.
+      - intros. apply H2. rewrite H5. apply in_or_app. destruct (in_app_or _ _ _  H4).
+        left; exact H7. right; right; exact H7.
+        intro. destruct H7. subst. induction x in H, H4, H3. inversion H. contradiction H5. 
+        apply IHx. simpl in H; inversion H; exact H7.
+        apply in_or_app; right; left; reflexivity.
+        inversion H4. rewrite H1 in H. inversion H. contradiction H7. apply in_or_app; right; left; reflexivity.
+        exact H1.
+        contradiction H6.
+      - apply H1. left; reflexivity.
+  Qed.
+
+  Lemma incl_supp_rsum {m n} a (r : Rel.R m) (f : Rel.T m -> Rel.R n) : 
+    List.In a (Rel.supp r) -> incl (Rel.supp (f a)) (Rel.supp (Rel.rsum r f)).
+  Proof.
+    repeat intro. apply Rel.p_fs. rewrite Rel.p_rsum.
+    generalize (Rel.p_fs_r _ _ _ H0). intro.
+    decompose record (in_split _ _ H). rewrite H3. 
+    rewrite map_app, list_sum_append.
+    replace (list_sum (List.map (fun t0 => Rel.memb r t0 * Rel.memb (f t0) a0) (a :: x0)))
+       with (Rel.memb r a * Rel.memb (f a) a0 + list_sum (List.map (fun t0 => Rel.memb r t0 * Rel.memb (f t0) a0) x0)).
+    2: { reflexivity. }
+    rewrite plus_assoc. rewrite plus_comm. rewrite plus_assoc. change 0 with (0 + 0).
+    apply plus_le_lt_compat. omega.
+    unfold lt. change 1 with (1*1). apply mult_le_compat.
+    apply Rel.p_fs_r. exact H.
+    apply Rel.p_fs_r. exact H0.
+  Qed.
+
+  Lemma rsum_rsum_tech {m n o} (r : Rel.R m) (f : Rel.T m -> Rel.R n) (g : Rel.T n -> Rel.R o) (t : Rel.T o)
+    : forall l, incl l (Rel.supp r) ->
+      list_sum (List.map (fun x =>
+        list_sum (List.map (fun y => 
+          Rel.memb r y * Rel.memb (f y) x) l)
+          * Rel.memb (g x) t) (Rel.supp (Rel.rsum r f))) 
+      = list_sum (List.map (fun z =>
+          Rel.memb r z * list_sum (List.map (fun w => 
+            Rel.memb (f z) w * Rel.memb (g w) t) (Rel.supp (f z)))) l).
+  Proof.
+    induction l; simpl. induction (Rel.supp (Rel.rsum r f)); intuition. intro.
+    transitivity
+      (list_sum (List.map (fun x =>
+        Rel.memb r a * Rel.memb (f a) x * Rel.memb (g x) t
+        + list_sum (List.map (fun y : Rel.T m => Rel.memb r y * Rel.memb (f y) x) l) * Rel.memb (g x) t)
+        (Rel.supp (Rel.rsum r f)))).
+    1: { f_equal. f_equal. extensionality x. rewrite mult_plus_distr_r. reflexivity. }
+    rewrite (list_sum_plus (fun x => Rel.memb r a * Rel.memb (f a) x * Rel.memb (g x) t)
+      (fun x => list_sum (List.map (fun y => Rel.memb r y * Rel.memb (f y) x) l) * Rel.memb (g x) t)).
+    rewrite IHl. f_equal.
+    transitivity (list_sum (List.map (fun x => 
+      Rel.memb r a * (Rel.memb (f a) x * Rel.memb (g x) t)) (Rel.supp (Rel.rsum r f)))).
+    1: { f_equal. f_equal. extensionality x. rewrite mult_assoc. reflexivity. }
+    rewrite (list_sum_times_l (Rel.memb r a) (fun x => Rel.memb (f a) x * Rel.memb (g x) t)).
+    f_equal.
+    apply rsum_rsum_list_sum. apply Rel.p_nodup. apply Rel.p_nodup.
+    apply incl_supp_rsum. apply H. left; reflexivity. 
+    intros. replace (Rel.memb (f a) x) with 0. omega.
+    destruct (or_eq_lt_n_O (Rel.memb (f a) x)). omega.
+    generalize (Rel.p_fs _ _ _ H2). intro. contradiction H1.
+    repeat intro. apply H. right. exact H0.
+  Qed.
 
   Lemma rsum_rsum {m n o} (r : Rel.R m) (f : Rel.T m -> Rel.R n) (g: Rel.T n -> Rel.R o) 
     : Rel.rsum (Rel.rsum r f) g = Rel.rsum r (fun x => Rel.rsum (f x) g).
   Proof.
-    admit.
-  Admitted.
+    apply Rel.p_ext; intro.
+    repeat rewrite Rel.p_rsum.
+    transitivity 
+      (list_sum (List.map (fun x => 
+         list_sum (List.map (fun y => 
+           Rel.memb r y * Rel.memb (f y) x) (Rel.supp r)) 
+         * Rel.memb (g x) t) (Rel.supp (Rel.rsum r f)))).
+    1: { f_equal. f_equal. extensionality x. rewrite Rel.p_rsum. reflexivity. }
+    transitivity
+      (list_sum (List.map (fun z => Rel.memb r z * 
+       list_sum (List.map (fun w => Rel.memb (f z) w * Rel.memb (g w) t) (Rel.supp (f z)))) (Rel.supp r))).
+    2: { f_equal. f_equal. extensionality z. rewrite Rel.p_rsum. reflexivity. }
+    apply rsum_rsum_tech.
+    apply incl_refl.
+  Qed.
 
   Lemma sel_rsum {m n} (r : Rel.R m) (p : Rel.T n -> bool) (f : Rel.T m -> Rel.R n)
     : Rel.sel (Rel.rsum r f) p = Rel.rsum r (fun x => (Rel.sel (f x) p)).
   Proof.
-    admit.
-  Admitted.
+    apply Rel.p_ext; intro. destruct (p t) eqn:ep.
+    + rewrite Rel.p_selt. repeat rewrite Rel.p_rsum.
+      induction (Rel.supp r); intuition.
+      simpl. rewrite Rel.p_selt. intuition. exact ep. exact ep.
+    + rewrite Rel.p_self. rewrite Rel.p_rsum. induction (Rel.supp r); intuition.
+      simpl. rewrite IHl, Rel.p_self. omega. exact ep. exact ep.
+  Qed.
 
   Lemma eq_sum_rsum {m n} r (f : Rel.T m -> Rel.T n) : Rel.sum r f = Rel.rsum r (fun x => Rel.Rsingle (f x)).
   Proof.
-    admit.
-  Admitted.
+    apply Rel.p_ext; intro. rewrite Rel.p_sum, Rel.p_rsum. induction (Rel.supp r); intuition.
+    simpl. destruct (Rel.T_dec _ (f a) t).
+    + rewrite e, (proj2 (Rel.T_eqb_eq _ _ _) eq_refl), Rel.p_single. simpl. omega.
+    + enough (Rel.T_eqb (f a) t = false). rewrite H, Rel.p_single_neq. omega.
+      exact n0. destruct (Rel.T_eqb (f a) t) eqn:e. contradiction n0. apply (proj1 (Rel.T_eqb_eq _ _ _)). exact e.
+      reflexivity.
+  Qed.
 
   Lemma sel_times_single {m n} (r : Rel.R m) (x : Rel.T n) p : 
     Rel.sel (Rel.times r (Rel.Rsingle x)) p = Rel.times (Rel.sel r (fun Vl => p (append Vl x))) (Rel.Rsingle x).
   Proof.
-    admit.
-  Admitted.
+    apply Rel.p_ext; intro. decompose record (exists_vector_append _ _ _ _ t eq_refl). destruct (p t) eqn:ep.
+    + rewrite Rel.p_selt. 
+      repeat rewrite (Rel.p_times _ _ _ _ _ _ _ (JMeq_eq H0)).
+      destruct (Rel.T_dec _ x x1).
+      - subst. rewrite Rel.p_selt. reflexivity. exact ep.
+      - rewrite Rel.p_single_neq. omega. exact n0.
+      - exact ep.
+    + rewrite Rel.p_self. rewrite (Rel.p_times _ _ _ _ _ _ _ (JMeq_eq H0)).
+      destruct (Rel.T_dec _ x x1).
+      - subst. rewrite Rel.p_self. omega. exact ep.
+      - rewrite Rel.p_single_neq. omega. exact n0.
+      - exact ep.
+  Qed.
+
+(*********)
+
+  Lemma filter_false A p (l : list A) : 
+    (forall x, List.In x l -> p x = false) -> filter p l = List.nil.
+  Proof.
+    elim l. auto.
+    intros h t IH Hp. simpl. rewrite Hp.
+    + apply IH. intros. apply Hp. right. exact H.
+    + left. reflexivity.
+  Qed.
+
+  Lemma sum_append : forall m n o (f : Rel.T m -> Rel.T n) r (t : Rel.T o),
+     n = m + o ->
+     (forall x, f x ~= append x t) ->
+     Rel.sum r f ~= Rel.times r (Rel.Rsingle t).
+  Proof.
+    intros. subst. apply eq_JMeq. eapply Rel.p_ext.
+    intros v. rewrite Rel.p_sum.
+    replace (fun x => Rel.T_eqb (f x) v) with (fun v' => Rel.T_eqb (append v' t) v).
+    decompose record (exists_vector_append _ _ _ _ v eq_refl). rename x into v1. rename x0 into v2.
+    rewrite H1, (Rel.p_times _ _ _ _ _ v1 v2 eq_refl).
+    destruct (Rel.T_dec _ t v2).
+    + replace (fun v' => Rel.T_eqb (append v' t) (append v1 v2)) with (fun v' => Rel.T_eqb v' v1).
+      rewrite e, Rel.p_single. eapply filter_supp_elim; simpl; intro.
+      - omega.
+      - destruct (or_eq_lt_n_O (Rel.memb r v1)); intuition.
+        contradiction H. apply Rel.p_fs. exact H2.
+      - extensionality v'. rewrite e. destruct (Rel.T_dec _ v' v1).
+        rewrite (proj2 (Rel.T_eqb_eq _ _ _) e0); symmetry. apply (proj2 (Rel.T_eqb_eq _ _ _)).
+        rewrite e0. reflexivity.
+        replace (Rel.T_eqb v' v1) with false. symmetry.
+        destruct (Rel.T_dec _ (append v' v2) (append v1 v2)). decompose record (vec_append_inj e0).
+        contradiction (n H).
+        destruct (Rel.T_eqb (append v' v2) (append v1 v2)) eqn:eapp.
+        rewrite (proj1 (Rel.T_eqb_eq _ _ _) eapp) in n0. contradiction n0. reflexivity.
+        reflexivity.
+        symmetry. destruct (Rel.T_eqb v' v1) eqn:e0.
+        rewrite (proj1 (Rel.T_eqb_eq _ _ _) e0) in n. contradiction n. reflexivity.
+        reflexivity.
+    + rewrite filter_false. replace (Rel.memb (Rel.Rsingle t) v2) with 0. simpl; omega.
+      rewrite Rel.p_single_neq. reflexivity. exact n.
+      intros v' Hv'. destruct (Rel.T_eqb (append v' t) (append v1 v2)) eqn:eapp.
+      decompose record (vec_append_inj (proj1 (Rel.T_eqb_eq _ _ _) eapp)). contradiction n.
+      reflexivity.
+    + extensionality v'. rewrite H0. reflexivity.
+  Qed.
+
+  Lemma rsum_append : forall m n o (f : Rel.T m -> Rel.R n) r (t : Rel.T o),
+     n = m + o ->
+     (forall x, f x ~= Rel.Rsingle (append x t)) ->
+     Rel.rsum r f ~= Rel.times r (Rel.Rsingle t).
+  Proof.
+    intros; subst. erewrite <- (sum_append _ _ _ (fun x => append x t)).
+    rewrite eq_sum_rsum. replace f with (fun (x:Rel.T m) => Rel.Rsingle (append x t)).
+    reflexivity. extensionality v. rewrite H0. reflexivity.
+    reflexivity.
+    intuition.
+  Qed.
+
+  Lemma supp_single_aux {A} (t : A) (l : list A) :
+    (forall (x y:A), {x = y} + {x <> y}) ->
+    List.In t l ->
+    (forall u, t <> u -> ~ List.In u l) ->
+    NoDup l ->
+    l = t::List.nil.
+  Proof.
+    intros. destruct l.
+    + inversion H.
+    + destruct (X a t).
+      - subst. destruct l; intuition.
+        destruct (X a t); subst.
+        inversion H1. contradiction H4. left. reflexivity.
+        exfalso. apply (H0 a). intuition. right; left; reflexivity.
+      - contradiction (H0 a). intuition. left; reflexivity.
+  Qed.
+
+  Lemma supp_single : forall n (t : Rel.T n), Rel.supp (Rel.Rsingle t) = t::List.nil.
+  Proof.
+    intros. apply supp_single_aux. apply (Rel.T_dec _).
+    apply Rel.p_fs. rewrite Rel.p_single. omega.
+    intros. intro. generalize (Rel.p_fs_r _ _ _ H0). rewrite Rel.p_single_neq. omega.
+    assumption.
+    apply Rel.p_nodup.
+  Qed.
+
+  Lemma rsum_from_single : forall m n t (f : Rel.T m -> Rel.R n), 
+    Rel.rsum (Rel.Rsingle t) f = f t.
+  Proof.
+    intros. apply Rel.p_ext. intro. rewrite Rel.p_rsum.
+    replace (Rel.supp (Rel.Rsingle t)) with (t::List.nil).
+    simpl. rewrite Rel.p_single. omega.
+    symmetry; apply supp_single.
+  Qed.
 
   Lemma rsum_times_single {m n o} (r : Rel.R m) (x : Rel.T n) (f : Rel.T (m + n) -> Rel.R o) :
     Rel.rsum (Rel.times r (Rel.Rsingle x)) f = Rel.rsum r (fun Vl => f (append Vl x)).
   Proof.
-    admit.
-  Admitted.
+    replace (Rel.times r (Rel.Rsingle x)) with (Rel.rsum r (fun v => Rel.Rsingle (append v x))).
+    rewrite rsum_rsum. f_equal.
+    extensionality Vl. apply rsum_from_single.
+    apply JMeq_eq. apply rsum_append. reflexivity. intuition.
+  Qed.
+
+  Lemma flatnat_plus : forall x y, Rel.flatnat (x + y) = max (Rel.flatnat x) (Rel.flatnat y).
+  Proof.
+    intros. destruct x; destruct y; simpl; reflexivity.
+  Qed.
+
+  Lemma flatnat_times : forall x y, Rel.flatnat (x * y) = min (Rel.flatnat x) (Rel.flatnat y).
+  Proof.
+    intros. destruct x; destruct y; simpl; intuition.
+    replace (x * 0) with 0. reflexivity. omega.
+  Qed.
+
+  Lemma flatnat_flatnat : forall x, Rel.flatnat (Rel.flatnat x) = Rel.flatnat x.
+  Proof.
+    intros. destruct x; reflexivity.
+  Qed.
 
   Lemma flat_rsum_flat {m n} (r : Rel.R m) (fr : Rel.T m -> Rel.R n) : 
     Rel.flat (Rel.rsum r (fun Vl => Rel.flat (fr Vl))) = Rel.flat (Rel.rsum r (fun Vl => fr Vl)).
   Proof.
-    admit.
-  Admitted.
+    apply Rel.p_ext; intro. repeat rewrite Rel.p_flat. repeat rewrite Rel.p_rsum.
+    induction (Rel.supp r); intuition.
+    simpl. repeat rewrite flatnat_plus. rewrite IHl. f_equal.
+    rewrite Rel.p_flat. repeat rewrite flatnat_times. f_equal.
+    apply flatnat_flatnat.
+  Qed.
 
   Lemma flat_Rsingle n (v : Rel.T n) : Rel.flat (Rel.Rsingle v) = Rel.Rsingle v.
   Proof.
@@ -393,6 +762,24 @@ Module Facts (Sql : SQL).
   Qed.
 
   Lemma sum_Rone_Rsingle n (f : Rel.T 0 -> Rel.T n) : Rel.sum Rel.Rone f = Rel.Rsingle (f (Vector.nil _)).
-  Proof. admit. Admitted.
+  Proof.
+    apply Rel.p_ext; intro. rewrite Rel.p_sum. replace (Rel.supp Rel.Rone) with (Vector.nil Rel.V ::List.nil).
+    destruct (Rel.T_dec _ (f (nil _)) t).
+    + rewrite e. rewrite Rel.p_single. 
+      simpl. rewrite e. simpl. rewrite (proj2 (Rel.T_eqb_eq _ _ _) eq_refl). simpl. rewrite Rel.p_one. omega.
+    + rewrite Rel.p_single_neq. simpl. destruct (Rel.T_eqb (f (nil _)) t) eqn:e; simpl; intuition.
+      contradiction n0. apply Rel.T_eqb_eq. exact e. exact n0.
+    + enough (forall x y z, Rel.supp Rel.Rone <> x::y::z).
+      enough (Rel.supp Rel.Rone <> List.nil).
+      destruct (Rel.supp Rel.Rone). contradiction H0. reflexivity.
+      destruct l. eapply (Vector.case0 (fun x => _ = x :: _)). reflexivity.
+      contradiction (H t0 t1 l). reflexivity.
+      intro. enough (List.In (nil _) (Rel.supp Rel.Rone)). rewrite H0 in H1; exact H1.
+      apply Rel.p_fs. rewrite Rel.p_one. omega.
+      intros. intro. generalize (Rel.p_nodup _ Rel.Rone).
+      rewrite H. eapply (Vector.case0 (fun a => NoDup (a :: _) -> False)).
+      eapply (Vector.case0 (fun a => NoDup (_ :: a :: _) -> False)). intro.
+      inversion H0. contradiction H3. simpl. left. reflexivity.
+  Qed.
 
 End Facts.

--- a/RelFacts.v
+++ b/RelFacts.v
@@ -243,7 +243,7 @@ Module Facts (Sql : SQL).
   Lemma filter_supp_elim n R r (P : list (Rel.T n) -> Prop) :
     (List.In r (Rel.supp R) -> P (r::List.nil)) ->
     (~ List.In r (Rel.supp R) -> P List.nil) ->
-    P (filter (fun (x0 : Rel.T n) => Rel.T_eqb x0 r) (Rel.supp R)).
+     P (filter (fun (x0 : Rel.T n) => Rel.T_eqb x0 r) (Rel.supp R)). 
   Proof.
     destruct (filter_supp_eq_tech _ (Rel.supp R) r (Rel.p_nodup _ R)).
     destruct (List.in_dec (Rel.T_dec _) r (Rel.supp R)); intros.

--- a/RewriteRules.v
+++ b/RewriteRules.v
@@ -1,12 +1,14 @@
+(* Will have to be updated with changes to SQL semantics *)
+
 Require Import Eqdep Lists.List Lists.ListSet Vector Arith.PeanoNat Syntax AbstractRelation Bool.Sumbool Tribool 
-  Semantics JMeq FunctionalExtensionality Omega Coq.Init.Specif ProofIrrelevance Util RelFacts SemFacts.
+  Semantics JMeq FunctionalExtensionality Omega Coq.Init.Specif ProofIrrelevance Util RelFacts SemFacts Common.
 
 Module RewriteRules (Db : DB) (Sql : SQL Db).
   Import Db.
   Import Sql.
 
   Module RF := RelFacts.Facts Db Sql.
-  Module SF := SemFacts.Facts Db Sql.
+  Module SF := SemFacts.Facts Db.
   Import RF.
   Import SF.
 

--- a/RewriteRules.v
+++ b/RewriteRules.v
@@ -152,12 +152,12 @@ Module RewriteRules (Sql : SQL).
     apply (j_nil_btbl_sem H10); intros; subst. rewrite <- H6. clear H4 H6 H10.
     apply (j_nil_btbl_sem H12); intros; subst. rewrite <- H4. clear H4 H5 H12.
     transitivity (Rel.memb (Sbtb h) ra).
-    + f_equal. apply JMeq_eq. apply rsum_id.
+    + f_equal. apply JMeq_eq. apply rsum_id. reflexivity.
       intros. apply cast_JMeq. apply Rel_Rone_times.
     + transitivity (Rel.memb (Sbtb0 h) rb).
       - eapply (j_commutative_join_btb _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H8 H9). Unshelve.
         shelve. shelve. exact H. exact H0.
-      - f_equal. symmetry. apply JMeq_eq. apply rsum_id.
+      - f_equal. symmetry. apply JMeq_eq. apply rsum_id. reflexivity.
         intros. apply cast_JMeq. apply Rel_Rone_times.
   Qed.
 
@@ -627,7 +627,7 @@ Module RewriteRules (Sql : SQL).
       apply sum_ext_dep.
       rewrite <- length_concat_list_sum. simpl. do 2 rewrite app_length. simpl. omega.
       rewrite <- Hlen, H15. do 2 rewrite map_length. rewrite <- H15. reflexivity.
-      rewrite <- H11. rewrite rsum_id. symmetry; exact HR2.
+      rewrite <- H11. rewrite rsum_id. symmetry; exact HR2. reflexivity.
       intros. apply cast_JMeq. apply Rel_Rone_times.
       intros. symmetry. 
       apply (cast_elim (Ev.env (s2::s1::G) -> Rel.T (length (tml_of_scm s1 1 ++ tml_of_scm s2 0))) Stml0).
@@ -674,13 +674,13 @@ Module RewriteRules (Sql : SQL).
         fr2 (fst (split r2)) (snd (split r2)) _ _ H8 H12)). Unshelve.
       apply eq_memb_dep.
           simpl; omega.
-          eapply (trans_JMeq (rsum_id _ _ _ _ _)). Unshelve. exact HR2.
+          eapply (trans_JMeq (rsum_id _ _ _ _ _ _)). Unshelve. exact HR2.
           symmetry; exact Hfr2.
           apply (split_ind r2 (fun m n p => r1 ~= append (fst p) (snd p))). intros. simpl.
           rewrite <- H3. apply (JMeq_trans Hr1). apply (JMeq_trans H1). exact Hr2.
           rewrite <- Hfr2. unfold flip.
           apply (split_ind r2 (fun m n p => (let (v1,v2) := p in append v2 v1) ~= append (snd p) (fst p))). 
-          intros. simpl. reflexivity.
+          intros. simpl. reflexivity. reflexivity.
           simpl; intro; apply cast_JMeq. rewrite <- H11. apply Rel_Rone_times.
     + enough (Rel.memb (Sbtbl h) r1 > 0).
       replace (Rel.memb (Sbtbl h) r1) with (Rel.memb R2 (flip r2)) in H3.
@@ -696,7 +696,7 @@ Module RewriteRules (Sql : SQL).
       rewrite <- H24. apply (j_nil_btbl_sem H23); intros; subst. rewrite <- H17.
       transitivity (Rel.memb (Sbtb0 h) r1). 
       eapply (j_commutative_join_btb _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H7 H21). Unshelve.
-      f_equal. symmetry; apply JMeq_eq; apply rsum_id. intro; apply cast_JMeq. apply Rel_Rone_times.
+      f_equal. symmetry; apply JMeq_eq; apply rsum_id. reflexivity. intro; apply cast_JMeq. apply Rel_Rone_times.
       f_equal; omega.
       exists (fst (split r2)); exists (snd (split r2)); split.
       apply (split_ind r2); simpl; intros. rewrite H4; reflexivity.
@@ -718,7 +718,7 @@ Module RewriteRules (Sql : SQL).
       symmetry. exact HR2. symmetry. apply cast_JMeq. reflexivity.
       transitivity (Rel.memb (Sbtb0 h) r1).
       eapply (j_commutative_join_btb _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H7 H21). Unshelve.
-      f_equal. symmetry. apply JMeq_eq. apply rsum_id. intro. apply cast_JMeq. apply Rel_Rone_times.
+      f_equal. symmetry. apply JMeq_eq. apply rsum_id. reflexivity. intro. apply cast_JMeq. apply Rel_Rone_times.
       f_equal. omega.
       exists (fst (split r2)); exists (snd (split r2)); split.
       apply (split_ind r2); simpl; intros. rewrite H4; reflexivity.
@@ -988,7 +988,7 @@ Module RewriteRules (Sql : SQL).
     + repeat rewrite rsum_single. rewrite sel_true. rewrite Rel_sum_sum.
       apply eq_sum_dep. reflexivity. unfold btm_subst_scm, btm_subst; repeat rewrite map_length. reflexivity.
       apply eq_sel_dep. reflexivity.
-      symmetry. eapply (trans_JMeq (rsum_id _ _ _ _ _)). Unshelve.
+      symmetry. eapply (trans_JMeq (rsum_id _ _ _ _ _ _)). Unshelve.
       apply cast_JMeq. apply (trans_JMeq (Rel_times_Rone _ _)). exact HRT.
       apply eq_JMeq. extensionality Vl. f_equal.
       rewrite (SQLSem3.jc_sem_fun_dep _ _ _ _ H11 _ _ _ eq_refl eq_refl H14). reflexivity.
@@ -1006,6 +1006,7 @@ Module RewriteRules (Sql : SQL).
         eapply (unnest_tml _ _ _ _ _ _ _ _ _ _ _ H10 H13 H16). exact HStml0'. Unshelve.
         rewrite <- H12. repeat rewrite map_length. reflexivity.
       - intros. inversion H9. apply (existT_eq_elim H2); intros. rewrite <- H4. reflexivity.
+      - reflexivity.
       - intros. simpl. apply cast_JMeq. apply Rel_Rone_times.
     + f_equal. rewrite <- H12. repeat rewrite map_length. omega.
   Qed.

--- a/SemFacts.v
+++ b/SemFacts.v
@@ -1,16 +1,13 @@
-Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq 
-  FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Syntax Semantics Util Tribool.
+Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq Common
+  FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Syntax Eval Util Tribool.
 
-Module Facts (Db : DB) (Sql : SQL Db).
+Module Facts (Db : DB).
 
   Import Db.
-  Import Sql.
 
   Module S2 := Sem2 Db.
   Module S3 := Sem3 Db.
-  Module Ev := Evl Db Sql.
-  Module SQLSem2 := SQLSemantics Db S2 Sql Ev.
-  Module SQLSem3 := SQLSemantics Db S3 Sql Ev.
+  Module Ev := Evl Db.
 
   Lemma projT1_env_app G1 G2 h1 h2 : 
     projT1 (Ev.env_app G1 G2 h1 h2) = projT1 h1 ++ projT1 h2.

--- a/SemFacts.v
+++ b/SemFacts.v
@@ -1,28 +1,27 @@
 Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq Common
   FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Syntax Eval Util Tribool.
 
-Module Facts (Db : DB).
+Module Facts.
 
   Import Db.
 
-  Module S2 := Sem2 Db.
-  Module S3 := Sem3 Db.
-  Module Ev := Evl Db.
+  Module S2 := Sem2.
+  Module S3 := Sem3.
 
   Lemma projT1_env_app G1 G2 h1 h2 : 
-    projT1 (Ev.env_app G1 G2 h1 h2) = projT1 h1 ++ projT1 h2.
+    projT1 (Evl.env_app G1 G2 h1 h2) = projT1 h1 ++ projT1 h2.
   Proof.
     destruct h1. destruct h2. reflexivity.
   Qed.
 
   Lemma projT1_env_of_tuple G x : 
-    projT1 (Ev.env_of_tuple G x) = to_list x.
+    projT1 (Evl.env_of_tuple G x) = to_list x.
   Proof.
     induction G.
     + simpl in x. eapply (case0 (fun v => List.nil = to_list v) _ x). Unshelve. reflexivity.
     + simpl. simpl in x. 
       enough (forall v1 v2, x = append v1 v2 -> 
-        to_list v1 ++ projT1 (Ev.env_of_tuple G v2) = to_list x).
+        to_list v1 ++ projT1 (Evl.env_of_tuple G v2) = to_list x).
       erewrite <- (H (fst (split x)) (snd (split x))). reflexivity.
       apply JMeq_eq.
       apply (split_ind x (fun m n p => x ~= append (fst p) (snd p))).
@@ -30,11 +29,11 @@ Module Facts (Db : DB).
       intros. rewrite H. rewrite to_list_append. f_equal. apply IHG.
   Qed.
 
-  Lemma subenv1_app : forall G1 G2 h1 h2, Ev.subenv1 (Ev.env_app G1 G2 h1 h2) = h1.
+  Lemma subenv1_app : forall G1 G2 h1 h2, Evl.subenv1 (Evl.env_app G1 G2 h1 h2) = h1.
   Proof.
-    intros. destruct h1. destruct h2. unfold Ev.env_app. simpl.
+    intros. destruct h1. destruct h2. unfold Evl.env_app. simpl.
     destruct (Nat.eqb_eq (length (concat (G1 ++ G2))) (length (x ++ x0))).
-    unfold Ev.subenv1. apply Ev.env_eq. simpl. replace (length (concat G1)) with (length x).
+    unfold Evl.subenv1. apply Evl.env_eq. simpl. replace (length (concat G1)) with (length x).
     rewrite firstn_app. replace (length x - length x) with O.
     replace x with (x ++ firstn 0 x0) at 3. f_equal.
     apply List.firstn_all. rewrite firstn_O. apply app_nil_r.
@@ -42,35 +41,35 @@ Module Facts (Db : DB).
     symmetry. apply Nat.eqb_eq. exact e.
   Qed.
 
-  Lemma subenv2_app : forall G1 G2 h1 h2, Ev.subenv2 (Ev.env_app G1 G2 h1 h2) = h2.
+  Lemma subenv2_app : forall G1 G2 h1 h2, Evl.subenv2 (Evl.env_app G1 G2 h1 h2) = h2.
   Proof.
-    intros. destruct h1. destruct h2. unfold Ev.env_app. simpl.
+    intros. destruct h1. destruct h2. unfold Evl.env_app. simpl.
     destruct (Nat.eqb_eq (length (concat (G1 ++ G2))) (length (x ++ x0))).
-    unfold Ev.subenv2. apply Ev.env_eq. simpl. replace (length (concat G1)) with (length x).
-    rewrite Ev.skipn_append. reflexivity.
+    unfold Evl.subenv2. apply Evl.env_eq. simpl. replace (length (concat G1)) with (length x).
+    rewrite Evl.skipn_append. reflexivity.
     symmetry. apply Nat.eqb_eq. exact e.
   Qed.
 
 
 
-  Lemma env_app_nil_l : forall G h1 h2, Ev.env_app List.nil G h1 h2 = h2.
+  Lemma env_app_nil_l : forall G h1 h2, Evl.env_app List.nil G h1 h2 = h2.
   Proof.
-    intros. apply Ev.env_eq. destruct h1. simpl. replace x with (@List.nil Rel.V). reflexivity.
+    intros. apply Evl.env_eq. destruct h1. simpl. replace x with (@List.nil Rel.V). reflexivity.
     destruct x; intuition.
     simpl in e. discriminate e.
   Qed.
 
-  Lemma env_hd_hd : forall a s G (h : Ev.env ((a::s)::G)) x, 
-    List.hd_error (projT1 h) = Some x -> Ev.env_hd h = x.
+  Lemma env_hd_hd : forall a s G (h : Evl.env ((a::s)::G)) x, 
+    List.hd_error (projT1 h) = Some x -> Evl.env_hd h = x.
   Proof.
     intros. enough (hd_error (projT1 h) <> None).
-    destruct h. unfold Ev.env_hd.
-    rewrite (Ev.unopt_pi _ _ H0). generalize dependent H0. rewrite H. intro. reflexivity.
+    destruct h. unfold Evl.env_hd.
+    rewrite (Evl.unopt_pi _ _ H0). generalize dependent H0. rewrite H. intro. reflexivity.
     rewrite H. intro. discriminate H0.
   Qed.
 
-  Lemma env_tl_tl : forall a s G (h : Ev.env ((a::s)::G)),
-    projT1 (Ev.env_tl h) = List.tl (projT1 h).
+  Lemma env_tl_tl : forall a s G (h : Evl.env ((a::s)::G)),
+    projT1 (Evl.env_tl h) = List.tl (projT1 h).
   Proof.
     intros. destruct h. simpl. reflexivity.
   Qed.

--- a/SemFacts.v
+++ b/SemFacts.v
@@ -94,7 +94,7 @@ Module Facts.
   Proof.
     destr_tribool.
   Qed.
-
+  
   Lemma S3_is_btrue_and_elim (b1 b2 : tribool) (P : Prop) :
     (S3.is_btrue b1 = true -> S3.is_btrue b2 = true -> P) ->
     S3.is_btrue (b1 && b2) = true -> P.

--- a/Semantics.v
+++ b/Semantics.v
@@ -66,16 +66,6 @@ Module SQLSemantics (Sem: SEM) (Sql : SQL).
     induction H; constructor; intuition.
   Qed.
 
-  (* alternate -- not stronger but easier -- version of sum *)
-
-  Axiom R_sum : forall m n, Rel.R m -> (Rel.T m -> Rel.R n) -> Rel.R n.
-  Implicit Arguments R_sum [m n].
-
-  (* singleton rel *)
-  Definition R_single {m} : Rel.T m -> Rel.R m :=
-    fun t => Rel.sum Rel.Rone (fun _ => t).
-
-
   (* NOTE: the ordering in the LATERAL list of lists grows dependencies left to right, while each of the 
      inner lists has the same ordering (right to left) as contexts *)
   Inductive j_q_sem (d : Db.D) : forall G (s : Scm), prequery -> (env G -> Rel.R (List.length s)) -> Prop := 
@@ -184,7 +174,11 @@ Module SQLSemantics (Sem: SEM) (Sql : SQL).
       j_btbl_sem d G (G1 ++ G0) (btb::btbl)
         (fun h =>
          let Rbtb := Sbtb h in
+         Rel.rsum Rbtb (fun Vl => cast _ _ e (Rel.times (Sbtbl (Evl.env_app _ _ (Evl.env_of_tuple _ Vl) h)) (Rel.Rsingle Vl))))
+(*
+         let Rbtb := Sbtb h in
          R_sum Rbtb (fun Vl => cast _ _ e (Rel.times (R_single Vl) (Sbtbl (Evl.env_app _ _ (Evl.env_of_tuple _ Vl) h)))))
+*)
 (*         let Rbtbl := Sbtbl h in
          R_sum Rbtbl (fun Vl => cast _ _ e (Rel.times (Sbtb (Evl.env_app _  _ (Evl.env_of_tuple _ Vl) h)) (R_single Vl))))
 *)

--- a/Semantics.v
+++ b/Semantics.v
@@ -1,217 +1,12 @@
 Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Syntax AbstractRelation Bool.Sumbool Tribool JMeq 
-  FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Util RelFacts.
+  FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Util RelFacts Common Eval.
 
-Module Type EV (Db : DB) (Sql : SQL Db).
-
+Module SQLSemantics (Db : DB) (Sem: SEM Db) (Sql : SQL Db).
   Import Db.
+  Import Sem.
   Import Sql.
-
-  Parameter preenv : Type.  (* environment (for evaluation) *)
-  Parameter env : Ctx -> Type.
-  Parameter env_lookup  : forall G : Ctx, env G -> FullVar -> option Value.
-
-  Parameter j_tm_sem : forall G, pretm -> (env G -> Value) -> Prop.
-  Parameter j_tml_sem : forall G (tml : list pretm), (env G -> Rel.T (List.length tml)) -> Prop.
-
-  Hypothesis j_tm_sem_fun :
-    forall G t St, j_tm_sem G t St -> forall St0, j_tm_sem G t St0 -> St = St0.
-  Hypothesis j_tml_sem_fun :
-    forall G tml Stml, j_tml_sem G tml Stml -> forall Stml0, j_tml_sem G tml Stml0 -> Stml = Stml0.
-
-  Hypothesis env_of_tuple : forall G, forall Vl : Db.Rel.T (list_sum (List.map (List.length (A:=Name)) G)), env G.
-
-  Hypothesis length_tmlist : forall c0, length (tmlist_of_ctx c0) = length (concat c0).
-  Hypothesis length_tolist : forall A n (v : Vector.t A n), length (to_list v) = n.
-
-  Parameter Vector_combine : forall A B n, Vector.t A n -> Vector.t B n -> Vector.t (A * B) n.
-
-  Hypothesis env_app : forall G1 G2, env G1 -> env G2 -> env (G1++G2).
-
-End EV.
-
-Fixpoint findpos {A} (l : list A) (p : A -> bool) start {struct l} : option nat := 
-  match l with
-  | List.nil => None
-  | List.cons a l0 => if p a then Some start else findpos l0 p (S start)
-  end.
-
-Module Evl (Db : DB) (Sql : SQL Db) <: EV Db Sql.
-  Import Db.
-  Import Sql.
-
-  Definition preenv := list Value. (* environment (for evaluation) *)
-  Definition env := fun (g : Ctx) => 
-    { h : preenv & (List.length (List.concat g) =? List.length h) = true }. 
-
-  Fixpoint scm_env s (h : preenv) {struct s} : list (Name * Value) * preenv := 
-    match s, h with
-    | List.nil, _ => (List.nil, h)
-    | _, List.nil => (List.nil, List.nil)
-    | a::s0, v::h0 => let (sh,h') := scm_env s0 h0 in ((a,v)::sh,h')
-    end. 
-
-  Fixpoint ctx_env G (h : preenv) {struct G} : list (list (Name * Value)) :=
-    match G with
-    | List.nil => List.nil
-    | s::G0 => let (sh,h') := scm_env s h in sh :: ctx_env G0 h'
-    end.
-
-  Definition env_lookup : forall G : Ctx, env G -> FullVar -> option Value :=
-    fun G h x => let (n,a) := x in
-      bind (nth_error (ctx_env G (projT1 h)) n)
-        (fun sh => bind (find (fun x => if Db.Name_dec (fst x) a then true else false) sh)
-          (fun p => ret (snd p))).
-
-  Lemma findpos_Some A (s : list A) p :
-    forall m n, findpos s p m = Some n -> n < m + length s.
-  Proof.
-    elim s; simpl; intros; intuition.
-    + discriminate H.
-    + destruct (p a); intuition.
-      - injection H0. omega. 
-      - pose (H _ _ H0). omega.
-  Qed.
-
-  Lemma j_var_nth_aux (h : list Value) s a : forall i,
-    findpos s (fun x => if Db.Name_dec x a then true else false) 0 = Some i ->
-    length s = length h ->
-    { v : Value & nth_error h i = Some v }.
-  Proof.
-    intros. cut (nth_error h i <> None).
-    + destruct (nth_error h i); intuition. exists v; reflexivity.
-    + apply nth_error_Some. rewrite <- H0. pose (findpos_Some _ _ _ _ _ H). omega.
-  Qed.
-
-  Lemma nth_error_map A B n a (f : A -> B) : 
-    forall (l : list A), nth_error l n = Some a ->
-    nth_error (List.map f l) n = Some (f a).
-  Proof.
-    elim n; simpl.
-    + intro l; destruct l; simpl; intuition.
-      - discriminate H.
-      - injection H. intro. rewrite H0. reflexivity.
-    + intros m IH l; destruct l; simpl; intuition. discriminate H.
-  Qed.
-
-  Lemma nth_error_map_r A B n b (f : A -> B) : 
-    forall (l : list A), nth_error (List.map f l) n = Some b ->
-    { a : A & nth_error l n = Some a /\ b = f a }.
-  Proof.
-    elim n; simpl.
-    + intro l; destruct l; simpl; intuition.
-      - discriminate H.
-      - injection H. intro. exists a. rewrite H0. auto.
-    + intros m IH l; destruct l; simpl; intuition. discriminate H.
-  Qed.
-
-(*
-  Lemma env_scm_length (G : Ctx) (h : env G) : forall n s, 
-    List.nth_error G n = Some s -> { h0 : list Value & List.nth_error (projT1 h) n = Some h0 /\ length s = length h0 }.
-  Proof.
-    intros. destruct h. pose (nth_error_map _ _ _ _ (@length Name) _ H).
-    clearbody e0. rewrite e in e0. destruct (nth_error_map_r _ _ _ _ _ _ e0).
-    destruct a. exists x0. simpl. auto.
-  Qed.
-*)
-
-  Definition unopt {A} : forall (x : option A), x <> None -> A.
-    refine (fun x => match x as x0 return (x0 <> None -> A) with Some x' => fun _ => x' | None => _ end).
-    intro Hfalse. contradiction Hfalse. reflexivity.
-  Defined.
-
-  Lemma unopt_pi {A} (x : option A) Hx Hx' : unopt x Hx = unopt x Hx'.
-  Proof.
-    destruct x; intuition.
-    contradiction Hx. reflexivity.
-  Qed.
-
-  Lemma p_scm_preenv s G (h : preenv) :
-    length h = length (List.concat (s::G)) ->
-    forall y h0, scm_env s h = (y,h0) ->
-    length y = length s /\ length h0 = length h - length s.
-  Proof.
-    intros. generalize s, H, y, h0, H0. clear s H y h0 H0. induction h; simpl; intros.
-    + destruct s.
-      - simpl in H0. injection H0. intros. subst. intuition.
-      - simpl in H. discriminate H.
-    + destruct s.
-      - simpl. simpl in H0. injection H0; intros; subst. simpl; intuition.
-      - simpl in H0. destruct (scm_env s h) eqn:e0. injection H0; intros; clear H0. 
-        simpl in H. injection H. intro. clear H.
-        destruct (IHh _ H0 _ _ e0). subst. split.
-        * simpl. rewrite H. reflexivity.
-        * rewrite H3. simpl. reflexivity.
-  Qed.
-
-  Lemma p_scm_env s G (h : env (s::G)) :
-    forall y p, scm_env s (projT1 h) = (y,p) ->
-    length y = length s /\ length p = length (projT1 h) - length s.
-  Proof.
-    intros. destruct h. simpl in e. eapply (p_scm_preenv _ G). symmetry.
-    apply Nat.eqb_eq. exact e. exact H.
-  Qed.
-
-  Definition env_hd {a} {s} {G} : env ((a::s)::G) -> Value.
-    refine (fun h => unopt (List.hd_error (projT1 h)) _).
-    destruct h. simpl. destruct x; simpl; intuition. discriminate H.
-  Defined.
-
-  Definition env_tl {a} {s} {G} : env ((a::s)::G) -> env (s::G).
-    refine (fun h => _).
-    enough ((length (concat (s::G)) =? length (List.tl (projT1 h))) = true).
-    unfold env. econstructor. exact H.
-    destruct h. destruct x; simpl; intuition.
-  Defined.
-
-  Inductive j_var_sem : forall s, Name -> (env (s::List.nil) -> Value) -> Prop :=
-  | jvs_hd : forall a s, ~ List.In a s -> j_var_sem (a::s) a (fun h => env_hd h)
-  | jvs_tl : forall a s b, 
-      forall Sb, a <> b -> j_var_sem s b Sb -> j_var_sem (a::s) b (fun h => Sb (env_tl h)).
-
-  Theorem j_var_sem_fun :
-    forall s a Sa, j_var_sem s a Sa -> forall Sa0, j_var_sem s a Sa0 -> Sa = Sa0.
-  Proof.
-    intros s a Sa Ha. induction Ha.
-    + intros. inversion H0.
-      - apply (existT_eq_elim H5). intros _. apply JMeq_eq.
-      - contradiction H5. reflexivity.
-    + intros. inversion H0.
-      - contradiction H.
-      - apply (existT_eq_elim H3); clear H3; intros; subst.
-        rewrite (IHHa _ H6). reflexivity.
-  Qed.
-
-  Definition subenv1 {G1} {G2} : env (G1++G2) -> env G1.
-    refine (fun h => _).
-    enough ((length (concat G1) =? length (firstn (length (concat G1)) (projT1 h))) = true).
-    unfold env. econstructor. exact H.
-    destruct h. apply Nat.eqb_eq. symmetry. apply firstn_length_le.
-    simpl. rewrite <- (proj1 (Nat.eqb_eq _ _) e). rewrite concat_app. rewrite app_length. omega.
-  Defined.
-
-  Definition subenv2 {G1} {G2} : env (G1++G2) -> env G2.
-    refine (fun h => _).
-    enough ((length (concat G2) =? length (skipn (length (concat G1)) (projT1 h))) = true).
-    unfold env. econstructor. exact H.
-    destruct h. apply Nat.eqb_eq. simpl. rewrite length_skipn.
-    rewrite <- (proj1 (Nat.eqb_eq _ _) e). rewrite concat_app. rewrite app_length. omega.
-  Defined.
-
-  Inductive j_fvar_sem : forall G, nat -> Name -> (env G -> Value) -> Prop :=
-  | jfs_hd : forall s G a, 
-      forall Sa, j_var_sem s a Sa -> j_fvar_sem (s::G) O a (fun h => Sa (@subenv1 (s::List.nil) G h))
-  | jfs_tl : forall s G i a,
-      forall Sia, j_fvar_sem G i a Sia -> j_fvar_sem (s::G) (S i) a (fun h => Sia (@subenv2 (s::List.nil) G h)).
-
-  Theorem j_fvar_sem_fun :
-    forall G i a Sia, j_fvar_sem G i a Sia -> forall Sia0, j_fvar_sem G i a Sia0 -> Sia = Sia0.
-  Proof.
-    intros G i a Sia Hia. induction Hia.
-    + intros. inversion H0. apply (existT_eq_elim H2); clear H2; intros; subst. clear H2.
-      rewrite (j_var_sem_fun _ _ _ H _ H5). reflexivity.
-    + intros. inversion H. apply (existT_eq_elim H5); clear H5; intros; subst.
-      rewrite (IHHia _ H4). reflexivity.
-  Qed.
+  Module Ev := Evl Db.
+  Import Ev.
 
   Inductive j_tm_sem0 (G:Ctx) : pretm -> (env G -> Value) -> Prop :=
   | jts_const : forall c, j_tm_sem0 G (tmconst c) (fun _ => Db.c_sem c)
@@ -227,6 +22,7 @@ Module Evl (Db : DB) (Sql : SQL Db) <: EV Db Sql.
       j_tm_sem0 G t St -> j_tml_sem0 G tml Stml ->
       j_tml_sem0 G (t::tml) (fun h => Vector.cons _ (St h) _ (Stml h)).
 
+  Derive Inversion j_tml_nil_sem with (forall G S, j_tml_sem0 G List.nil S).
   Derive Inversion j_tml_cons_sem with (forall G t tml Stml, j_tml_sem0 G (t::tml) Stml) Sort Prop.
 
   (* we need to fool the kernel, because it doesn't accept instantiation to inductive types *)
@@ -251,134 +47,6 @@ Module Evl (Db : DB) (Sql : SQL Db) <: EV Db Sql.
       rewrite (j_tm_sem_fun _ _ _ H _ H3). rewrite (IHHtml _ H5). reflexivity.
   Qed.
 
-  Definition env_app : forall G1 G2, env G1 -> env G2 -> env (G1++G2).
-    refine (fun G1 G2 h1 h2 => existT _ (projT1 h1 ++ projT1 h2) _).
-    destruct h1. destruct h2. apply Nat.eqb_eq. 
-    rewrite concat_app. simpl. do 2 rewrite app_length. 
-    f_equal; apply Nat.eqb_eq.
-    exact e.
-    exact e0.
-  Defined.
-
-  Fixpoint env_of_tuple G : Db.Rel.T (list_sum (List.map (List.length (A:=Name)) G)) -> env G.
-    refine 
-      ((match G as G0 return (G = G0 -> Db.Rel.T (list_sum (List.map (@length Name) G0)) -> env G0) with
-      | List.nil => _
-      | List.cons s G1 => _
-      end) eq_refl).
-    + refine (fun _ _ => existT _ List.nil _). reflexivity.
-    + simpl. intros. pose (p := split X); clearbody p.
-      apply (env_app (s :: List.nil)).
-      - eapply (existT _ (Vector.to_list (fst p)) _). Unshelve. simpl.
-        rewrite length_to_list. rewrite app_length. simpl. apply Nat.eqb_eq. omega.
-      - apply (env_of_tuple _ (snd p)).
-  Defined.
-
-  Definition Vector_combine {A} {B} {n} : Vector.t A n -> Vector.t B n -> Vector.t (A * B) n :=
-    Vector.rect2 (fun n0 _ _ => Vector.t (A*B) n0) (Vector.nil _)
-    (fun m _ _ acc a b => Vector.cons _ (a,b) _ acc).
-
-  Lemma length_tmlist c0 : length (tmlist_of_ctx c0) = length (concat c0).
-  Proof.
-    unfold tmlist_of_ctx. unfold mapi. generalize 0.
-    elim c0; intuition. 
-    simpl. do 2 rewrite app_length. rewrite cmap_length.
-    f_equal. apply H.
-  Qed.
-
-  Lemma length_tolist A n (v : Vector.t A n): length (to_list v) = n.
-  Proof.
-    elim v; simpl; intuition.
-  Qed.
-
-  Lemma nth_error_app2_eq {A} (G2:list A) n : forall G1, nth_error (G2 ++ G1) (length G2 + n) = nth_error G1 n.
-  Proof.
-    elim G2; auto.
-  Qed.
-
-  Lemma scm_env_skipn s : forall l h h0, scm_env s h = (l, h0) -> h0 = skipn (length s) h.
-  Proof.
-    induction s.
-    + simpl; intros. injection H; intuition.
-    + intros. destruct h.
-      - simpl in H. simpl. injection H; intuition.
-      - simpl in H. simpl. destruct (scm_env s h) eqn:e. injection H. intros. 
-        subst. apply (IHs _ _ _ e).
-  Qed.
-
-  Lemma skipn_skipn {A} m n : forall (l : list A), skipn m (skipn n l) = skipn (m+n) l.
-  Proof.
-    induction n.
-    + simpl; intuition. replace (m + 0) with m. reflexivity. omega.
-    + intro. destruct l.
-      - simpl. destruct m; simpl; intuition.
-      - replace (m + S n) with (S (m + n)). simpl. apply IHn.
-        omega.
-  Qed.
-
-  Lemma skipn_append {A} (l1 l2 : list A) : skipn (length l1) (l1 ++ l2) = l2.
-  Proof.
-    induction l1; simpl; intuition.
-  Qed.
-
-  Lemma nth_error_ctx_env_app_eq G2 n : forall G1 h1 h2,
-      length (concat G1) = length h1 ->
-      length (concat G2) = length h2 ->
-      nth_error (ctx_env (G2 ++ G1) (h2 ++ h1)) (length G2 + n)
-      = nth_error (ctx_env G1 h1) n.
-  Proof.
-    induction G2; simpl; intuition.
-    + replace h2 with (@List.nil Value). reflexivity.
-      symmetry. apply length_zero_iff_nil. intuition.
-    + destruct (scm_env a (h2++h1)) eqn:e. rewrite app_length in H0.
-      enough (length (h2++h1) = length (List.concat (a::G2++G1))).
-      destruct (p_scm_preenv _ _ _ H1 _ _ e).
-      simpl in H1. rewrite concat_app in H1. repeat rewrite app_length in H1.
-      enough (length p = length (concat G2) + length (concat G1)).
-      rewrite <- (firstn_skipn (length (concat G2)) p).
-      replace (skipn (length (concat G2)) p) with h1.
-      apply IHG2. exact H. rewrite firstn_length. rewrite H4. rewrite min_l. reflexivity. omega.
-      rewrite (scm_env_skipn _ _ _ _ e). 
-      rewrite skipn_skipn. 
-      replace (length (concat G2) + length a) with (length h2). symmetry. apply skipn_append.
-      omega.
-      rewrite H3. rewrite app_length. omega.
-      simpl. rewrite concat_app. do 3 rewrite app_length. omega.
-  Qed.
-
-  Lemma length_env {G} (h: env G) : length (projT1 h) = length (concat G).
-  Proof.
-    destruct h. simpl. symmetry. apply Nat.eqb_eq. exact e.
-  Qed.
-
-  Definition env_of_list (G:Ctx) : forall (l: list Value), length l = length (List.concat G) -> env G.
-    intros. exists l. apply Nat.eqb_eq. intuition.
-  Defined.
-
-  Lemma bool_eq_pi : forall (b1 b2 : bool) (e1 e2 : b1 = b2), e1 = e2.
-  Proof.
-    intros b1 b2. enough (forall (x y : bool), x = y \/ x <> y).
-    destruct b1, b2. 
-    + intro. eapply (K_dec H (fun e => forall e2 : true = true, e = e2) _ e1). Unshelve.
-      simpl. intro. eapply (K_dec H (fun e => eq_refl = e) _ e2). Unshelve. reflexivity.
-    + intros. discriminate e1.
-    + intros. discriminate e1.
-    + intro. eapply (K_dec H (fun e => forall e2 : false = false, e = e2) _ e1). Unshelve.
-      simpl. intro. eapply (K_dec H (fun e => eq_refl = e) _ e2). Unshelve. reflexivity.
-    + intros. destruct (Bool.bool_dec x y); intuition.
-  Qed.
-
-  Lemma env_eq {G} (h1 h2: env G) : projT1 h1 = projT1 h2 -> h1 = h2.
-  Proof.
-    destruct h1. destruct h2. simpl. intro. subst. f_equal. apply bool_eq_pi.
-  Qed.
-
-  Lemma env_JMeq {G1} {G2} (h1: env G1) (h2: env G2): G1 = G2 -> projT1 h1 = projT1 h2 -> h1 ~= h2.
-  Proof.
-    intro. subst.
-    destruct h1. destruct h2. simpl. intro. subst. apply eq_JMeq. f_equal. apply bool_eq_pi.
-  Qed.
-
   Lemma j_tm_sem_weak G G' t St (Ht : j_tm_sem G t St) :
     j_tm_sem (G' ++ G) (tm_lift t (length G')) (fun h => St (subenv2 h)).
   Proof.
@@ -398,170 +66,40 @@ Module Evl (Db : DB) (Sql : SQL Db) <: EV Db Sql.
     induction H; constructor; intuition.
   Qed.
 
-End Evl.
+  (* alternate -- not stronger but easier -- version of sum *)
 
-Module Type SEM (Db : DB).
-  Import Db.
-  Parameter B : Type.
-  Parameter btrue : B.
-  Parameter bfalse : B.
-  Parameter bmaybe : B.
-  Parameter band : B -> B -> B.
-  Parameter bor : B -> B -> B.
-  Parameter bneg : B -> B.
-  Parameter is_btrue : B -> bool.
-  Parameter is_bfalse : B -> bool.
-  Parameter of_bool : bool -> B.
-  Parameter veq : Value -> Value -> B.
+  Axiom R_sum : forall m n, Rel.R m -> (Rel.T m -> Rel.R n) -> Rel.R n.
+  Implicit Arguments R_sum [m n].
 
-  Hypothesis sem_bpred : forall n, (forall l : list BaseConst, length l = n -> bool) -> 
-    forall l : list Value, length l = n -> B.
+  (* singleton rel *)
+  Definition R_single {m} : Rel.T m -> Rel.R m :=
+    fun t => Rel.sum Rel.Rone (fun _ => t).
 
-  Hypothesis sem_bpred_elim : 
-    forall n (p : forall l, length l = n -> bool) (l : list Value) (Hl : length l = n) (P : B -> Prop),
-    (forall cl, monadic_map (fun val => val) l = Some cl -> forall Hcl : length cl = n, P (of_bool (p cl Hcl))) ->
-    (monadic_map (fun val => val) l = None -> P bmaybe) ->
-    P (sem_bpred n p l Hl).
-End SEM.
 
-Module Sem2 (Db : DB) <: SEM Db.
-  Import Db.
-  Definition B := bool.
-  Definition btrue := true.
-  Definition bfalse := false.
-  Definition bmaybe := false.
-  Definition band := andb.
-  Definition bor := orb.
-  Definition bneg := negb.
-  Definition is_btrue := fun (x : bool) => x.
-  Definition is_bfalse := fun (x : bool) => negb x.
-  Definition of_bool := fun (x : bool) => x.
-  Definition veq := fun v1 v2 => 
-    match v1, v2 with
-    | Some x1, Some x2 => c_eq x1 x2
-    | _, _ => false
-    end.
-
-  Definition sem_bpred_aux
-  : forall n (p : (forall l : list BaseConst, length l = n -> bool)), 
-      forall (l : list Value), length l = n -> 
-      { b : B & (forall x Hx, monadic_map (fun val => val) l = Some x -> b = of_bool (p x Hx)) /\
-                (monadic_map (fun val => val) l = None -> b = false)}.
-  Proof.
-    intros n p l H.
-    destruct (monadic_map (fun val => val) l) eqn:e.
-    + eexists (of_bool (p l0 _)). Unshelve. Focus 2. 
-      rewrite <- (length_monadic_map _ _ _ _ _ e). exact H. split.
-      - intros. injection H0. intro. generalize Hx. clear Hx. rewrite <- H1.
-        intro. f_equal. f_equal. eapply UIP.
-      - intro Hfalse. discriminate Hfalse.
-    + exists false. split; intros.
-      - discriminate H0.
-      - reflexivity.
-  Defined.
-
-  Definition sem_bpred 
-  : forall n, (forall l : list BaseConst, length l = n -> bool) -> 
-      forall l : list Value, length l = n -> B :=
-  fun n p l H => projT1 (sem_bpred_aux n p l H).
-
-  Lemma sem_bpred_elim n (p : forall l, length l = n -> bool) (l : list Value) (Hl : length l = n) (P : B -> Prop) :
-    (forall cl, monadic_map (fun val => val) l = Some cl -> forall Hcl : length cl = n, P (of_bool (p cl Hcl))) ->
-    (monadic_map (fun val => val) l = None -> P false) ->
-    P (sem_bpred n p l Hl).
-  intros. cut ((forall x Hx, monadic_map (fun val => val) l = Some x -> sem_bpred n p l Hl = of_bool (p x Hx)) /\
-                (monadic_map (fun val => val) l = None -> sem_bpred n p l Hl = false)).
-  + intro Hcut. destruct Hcut. destruct (monadic_map (fun val => val) l) eqn:e; simpl.
-    - assert (length l0 = n). rewrite <- Hl. symmetry. apply (length_monadic_map _ _ _ _ _ e).
-      rewrite (H1 _ H3). apply H. reflexivity. reflexivity.
-    - rewrite (H2 eq_refl). apply H0. reflexivity.
-  + apply (projT2 (sem_bpred_aux n p l Hl)).
-  Qed.
-
-End Sem2.
-
-Module Sem3 (Db : DB) <: SEM Db.
-  Import Db.
-  Definition B := tribool.
-  Definition btrue := ttrue.
-  Definition bfalse := tfalse.
-  Definition bmaybe := unknown.
-  Definition band := andtb.
-  Definition bor := ortb.
-  Definition bneg := negtb.
-  Definition is_btrue := Tribool.eqb ttrue.
-  Definition is_bfalse := Tribool.eqb tfalse.
-  Definition of_bool := tribool_of_bool.
-  Definition veq := fun v1 v2 => 
-    match v1, v2 with
-    | Some x1, Some x2 => tribool_of_bool (c_eq x1 x2)
-    | _, _ => unknown
-    end.
-
-  Definition sem_bpred_aux
-  : forall n (p : (forall l : list BaseConst, length l = n -> bool)), 
-      forall (l : list Value), length l = n -> 
-      { b : B & (forall x Hx, monadic_map (fun val => val) l = Some x -> b = of_bool (p x Hx)) /\
-                (monadic_map (fun val => val) l = None -> b = unknown)}.
-  Proof.
-    intros n p l H.
-    destruct (monadic_map (fun val => val) l) eqn:e.
-    + eexists (of_bool (p l0 _)). Unshelve. Focus 2. 
-      rewrite <- (length_monadic_map _ _ _ _ _ e). exact H. split.
-      - intros. injection H0. intro. generalize Hx. clear Hx. rewrite <- H1.
-        intro. f_equal. f_equal. eapply UIP.
-      - intro Hfalse. discriminate Hfalse.
-    + exists unknown. split; intros.
-      - discriminate H0.
-      - reflexivity.
-  Defined.
-
-  Definition sem_bpred 
-  : forall n, (forall l : list BaseConst, length l = n -> bool) -> 
-      forall l : list Value, length l = n -> B :=
-  fun n p l H => projT1 (sem_bpred_aux n p l H).
-
-  Lemma sem_bpred_elim n (p : forall l, length l = n -> bool) (l : list Value) (Hl : length l = n) (P : B -> Prop) :
-    (forall cl, monadic_map (fun val => val) l = Some cl -> forall Hcl : length cl = n, P (of_bool (p cl Hcl))) ->
-    (monadic_map (fun val => val) l = None -> P unknown) ->
-    P (sem_bpred n p l Hl).
-  intros. cut ((forall x Hx, monadic_map (fun val => val) l = Some x -> sem_bpred n p l Hl = of_bool (p x Hx)) /\
-                (monadic_map (fun val => val) l = None -> sem_bpred n p l Hl = unknown)).
-  + intro Hcut. destruct Hcut. destruct (monadic_map (fun val => val) l) eqn:e; simpl.
-    - assert (length l0 = n). rewrite <- Hl. symmetry. apply (length_monadic_map _ _ _ _ _ e).
-      rewrite (H1 _ H3). apply H. reflexivity. reflexivity.
-    - rewrite (H2 eq_refl). apply H0. reflexivity.
-  + apply (projT2 (sem_bpred_aux n p l Hl)).
-  Qed.
-
-End Sem3.
-
-Module SQLSemantics (Db : DB) (Sem: SEM Db) (Sql : SQL Db) (Ev : EV Db Sql).
-  Import Db.
-  Import Sem.
-  Import Sql.
-  Import Ev.
-
+  (* NOTE: the ordering in the LATERAL list of lists grows dependencies left to right, while each of the 
+     inner lists has the same ordering (right to left) as contexts *)
   Inductive j_q_sem (d : Db.D) : forall G (s : Scm), prequery -> (env G -> Rel.R (List.length s)) -> Prop := 
-  | jqs_sel : forall G b tml btb c,
-      forall G0 Sbtb Sc Stml e,
-      j_btb_sem d G G0 btb Sbtb ->
+  | jqs_sel : forall G b tml btbl c,
+      forall G0 Sbtbl Sc Stml s e,
+      j_btbl_sem d G G0 btbl Sbtbl ->
       j_cond_sem d (G0++G) c Sc ->
-      j_tml_sem (G0++G) (List.map fst tml) Stml ->
-      j_q_sem d G (List.map snd tml) (select b tml btb c) 
-        (fun h => let S1 := Sbtb h in
+      j_tml_sem (G0++G) (List.map fst tml) Stml -> 
+      s = List.map snd tml ->
+      j_q_sem d G s (select b tml btbl c) 
+        (fun h => let S1 := Sbtbl h in
                   let p  := fun Vl => Sem.is_btrue (Sc (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h)) in
                   let S2 := Rel.sel S1 p in
                   let f  := fun Vl => Stml (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h) in
                   let S := cast _ _ e (Rel.sum S2 f)
                   in if b then Rel.flat S else S)
-  | jqs_selstar : forall G b btb c,
-      forall G0 Sbtb Sc Stml e,
-      j_btb_sem d G G0 btb Sbtb ->
+  | jqs_selstar : forall G b btbl c,
+      forall s0 G0 Sbtbl Sc Stml e,
+      j_btbl_sem d G G0 btbl Sbtbl ->
       j_cond_sem d (G0++G) c Sc ->
       j_tml_sem (G0++G) (tmlist_of_ctx G0) Stml ->
-      j_q_sem d G (List.concat G0) (selstar b btb c) 
-        (fun h => let S1 := Sbtb h in
+      s0 = List.concat G0 ->
+      j_q_sem d G s0 (selstar b btbl c) 
+        (fun h => let S1 := Sbtbl h in
                   let p  := fun Vl => Sem.is_btrue (Sc (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h)) in
                   let S2 := Rel.sel S1 p in
                   let f  := fun Vl => Stml (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h) in
@@ -637,25 +175,38 @@ Module SQLSemantics (Db : DB) (Sem: SEM Db) (Sql : SQL Db) (Ev : EV Db Sql).
       j_tb_sem d G s T ST ->
       j_btb_sem d G G0 btb Sbtb -> length s = length s' ->
       j_btb_sem d G (s'::G0) ((T,s')::btb) (fun Vl => cast _ _ e (Rel.times (ST Vl) (Sbtb Vl)))
-  with j_in_q_sem (d : Db.D) : forall G, prequery -> (env G -> bool) -> Prop :=
-  | jiqs_sel : forall G b tml btb c,
-      forall G0 Sbtb Sc Stml,
+  with j_btbl_sem (d : Db.D) : forall G G', list (list (pretb * Scm)) -> (env G -> Rel.R (list_sum (List.map (length (A:=Name)) G'))) -> Prop :=
+  | jbtbls_nil : forall G, j_btbl_sem d G List.nil List.nil (fun _ => Rel.Rone) 
+  | jbtbls_cons : forall G btb btbl,
+      forall G0 G1 Sbtb Sbtbl e,
       j_btb_sem d G G0 btb Sbtb ->
+      j_btbl_sem d (G0 ++ G) G1 btbl Sbtbl ->
+      j_btbl_sem d G (G1 ++ G0) (btb::btbl)
+        (fun h =>
+         let Rbtb := Sbtb h in
+         R_sum Rbtb (fun Vl => cast _ _ e (Rel.times (R_single Vl) (Sbtbl (Ev.env_app _ _ (Ev.env_of_tuple _ Vl) h)))))
+(*         let Rbtbl := Sbtbl h in
+         R_sum Rbtbl (fun Vl => cast _ _ e (Rel.times (Sbtb (Ev.env_app _  _ (Ev.env_of_tuple _ Vl) h)) (R_single Vl))))
+*)
+  with j_in_q_sem (d : Db.D) : forall G, prequery -> (env G -> bool) -> Prop :=
+  | jiqs_sel : forall G b tml btbl c,
+      forall G0 Sbtbl Sc Stml,
+      j_btbl_sem d G G0 btbl Sbtbl ->
       j_cond_sem d (G0++G) c Sc ->
       j_tml_sem (G0++G) (List.map fst tml) Stml ->
-      j_in_q_sem d G (select b tml btb c) 
-        (fun h => let S1 := Sbtb h in
+      j_in_q_sem d G (select b tml btbl c) 
+        (fun h => let S1 := Sbtbl h in
                   let p  := fun Vl => Sem.is_btrue (Sc (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h)) in
                   let S2 := Rel.sel S1 p in
                   let f  := fun Vl => Stml (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h) in
                   let S := Rel.sum S2 f
                   in 0 <? Rel.card (if b then Rel.flat S else S))
-  | jiqs_selstar : forall G b btb c,
-      forall G0 Sbtb Sc,
-      j_btb_sem d G G0 btb Sbtb ->
+  | jiqs_selstar : forall G b btbl c,
+      forall G0 Sbtbl Sc,
+      j_btbl_sem d G G0 btbl Sbtbl ->
       j_cond_sem d (G0++G) c Sc ->
-      j_in_q_sem d G (selstar b btb c) 
-        (fun h => let S1 := Sbtb h in
+      j_in_q_sem d G (selstar b btbl c) 
+        (fun h => let S1 := Sbtbl h in
                   let p  := fun Vl => Sem.is_btrue (Sc (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h)) in
                   let S2 := Rel.sel S1 p in
 (*                  let f  := fun _ => Vector.nil Rel.V) in
@@ -684,9 +235,10 @@ no, we can simplify *)
   with jTs_ind_mut := Induction for j_tb_sem Sort Prop
   with jcs_ind_mut := Induction for j_cond_sem Sort Prop
   with jbTs_ind_mut := Induction for j_btb_sem Sort Prop
+  with jbTls_ind_mut := Induction for j_btbl_sem Sort Prop
   with jiqs_ind_mut := Induction for j_in_q_sem Sort Prop.
 
-  Combined Scheme j_sem_ind_mut from jqs_ind_mut, jTs_ind_mut, jcs_ind_mut, jbTs_ind_mut, jiqs_ind_mut.
+  Combined Scheme j_sem_ind_mut from jqs_ind_mut, jTs_ind_mut, jcs_ind_mut, jbTs_ind_mut, jbTls_ind_mut, jiqs_ind_mut.
 
 
   Derive Inversion j_q_sel_sem with (forall d G s b tml btb c Ssel, j_q_sem d G s (select b tml btb c) Ssel) Sort Prop.
@@ -697,6 +249,7 @@ no, we can simplify *)
   Derive Inversion j_tb_base_sem with (forall d G s x ST, j_tb_sem d G s (tbbase x) ST) Sort Prop.
   Derive Inversion j_tb_query_sem with (forall d G s q ST, j_tb_sem d G s (tbquery q) ST) Sort Prop.
   Derive Inversion j_cons_btb_sem with (forall d G G' T s tl Scons, j_btb_sem d G G' ((T,s)::tl) Scons) Sort Prop.
+  Derive Inversion j_cons_btbl_sem with (forall d G G' btb btbl Scons, j_btbl_sem d G G' (btb::btbl) Scons) Sort Prop.
   Derive Inversion j_iq_sel_sem with (forall d G b tml btb c Ssel, j_in_q_sem d G (select b tml btb c) Ssel) Sort Prop.
   Derive Inversion j_iq_selstar_sem with (forall d G b btb c Sss, j_in_q_sem d G (selstar b btb c) Sss) Sort Prop.
   Derive Inversion j_iq_union_sem with (forall d G b q1 q2 Sq, j_in_q_sem d G (qunion b q1 q2) Sq) Sort Prop.
@@ -720,12 +273,31 @@ no, we can simplify *)
     discriminate H5.
   Qed.
 
+  Lemma j_nil_btbl_sem :
+    forall d G G' Snil (P : Prop),
+       (forall (G0 G0': Ctx), G0 = G -> G0' = G' -> List.nil = G0' ->
+        (fun (_:Ev.env G) => Rel.Rone) ~= Snil -> P) ->
+       j_btbl_sem d G G' List.nil Snil -> P.
+  Proof.
+    intros.
+    enough (forall G0 G0' btbl0
+      (Snil0 : Ev.env G0 -> Rel.R (list_sum (List.map (length (A:=Name)) G0'))), 
+        j_btbl_sem d G0 G0' btbl0 Snil0 ->
+        G0 = G -> G0' = G' -> List.nil = btbl0 -> Snil0 ~= Snil -> P).
+    apply (H1 _ _ _ _ H0 eq_refl eq_refl eq_refl JMeq_refl).
+    intros G0 G0' btbl0 Snil0 H0'.
+    destruct H0'; intros. eapply H; auto. rewrite H1 in H4. exact H4.
+    discriminate H4.
+  Qed.
+
   Theorem j_sem_fun : forall d,
     (forall G s q Sq, j_q_sem d G s q Sq -> forall s0 Sq0, j_q_sem d G s0 q Sq0 -> s = s0 /\ Sq ~= Sq0) /\
     (forall G s T ST, j_tb_sem d G s T ST -> forall s0 ST0, j_tb_sem d G s0 T ST0 -> s = s0 /\ ST ~= ST0) /\
     (forall G c Sc, j_cond_sem d G c Sc -> forall Sc0, j_cond_sem d G c Sc0 -> Sc ~= Sc0) /\
     (forall G G' btb Sbtb, j_btb_sem d G G' btb Sbtb -> 
       forall G0' Sbtb0, j_btb_sem d G G0' btb Sbtb0 -> G' = G0' /\ Sbtb ~= Sbtb0) /\
+    (forall G G' btbl Sbtbl, j_btbl_sem d G G' btbl Sbtbl -> 
+      forall G0' Sbtbl0, j_btbl_sem d G G0' btbl Sbtbl0 -> G' = G0' /\ Sbtbl ~= Sbtbl0) /\
     (forall G q Sq, j_in_q_sem d G q Sq -> forall Sq0, j_in_q_sem d G q Sq0 -> Sq ~= Sq0).
   Proof.
     intro. apply j_sem_ind_mut.
@@ -734,25 +306,25 @@ no, we can simplify *)
       (* the Coq refiner generates an ill-typed term if we don't give enough parameters to this eapply *)
       eapply (j_q_sel_sem _ _ _ _ _ _ _ _ (fun _ _ s1 _ _ _ _ Ssel =>
         _ = s1 /\ (fun h =>
-        let S1 := Sbtb h in
+        let S1 := Sbtbl h in
         let p := fun Vl => is_btrue (Sc (Ev.env_app G0 G (Ev.env_of_tuple G0 Vl) h)) in
         let S2 := Rel.sel S1 p in
         let f := fun Vl => Stml (Ev.env_app G0 G (Ev.env_of_tuple G0 Vl) h) in
         let S := cast _ _ e (Rel.sum S2 f) in
         if b then Rel.flat S else S) ~= Ssel) _ H1). Unshelve.
       intros; simpl; subst. apply (existT_eq_elim H13); clear H13; intros; subst.
-      clear H3 H12. apply (existT_eq_elim (JMeq_eq H4)); clear H4; intros; subst.
-      clear H3. destruct (H _ _ H5); subst. pose (H11 := H0 _ H9); clearbody H11. 
+      clear H3. apply (existT_eq_elim (JMeq_eq H4)); clear H4; intros; subst.
+      clear H3. destruct (H _ _ H7); subst. pose (H11 := H0 _ H8); clearbody H11. 
       rewrite H4.
       rewrite H11.
-      replace e0 with e. replace Stml0 with Stml.
-      split; reflexivity. apply (Ev.j_tml_sem_fun _ _ _ j1 _ H10). apply UIP.
+      replace e1 with e. replace Stml0 with Stml.
+      split; reflexivity. apply (j_tml_sem_fun _ _ _ j1 _ H9). apply UIP.
     + intros. eapply (j_q_selstar_sem _ _ _ _ _ _ _ (fun _ _ _ _ _ _ _ => _) _ H1). Unshelve.
       intros; simpl; subst. apply (existT_eq_elim H12); clear H12; intros; subst.
-      clear H3 H11. apply (existT_eq_elim (JMeq_eq H4)); clear H4; intros; subst.
-      clear H3. destruct (H _ _ H6); subst. pose (H10 := H0 _ H8); clearbody H10. 
-      rewrite H4, H10. replace e0 with e. replace Stml0 with Stml.
-      split; reflexivity. apply (Ev.j_tml_sem_fun _ _ _ j1 _ H9). apply UIP.
+      clear H3. apply (existT_eq_elim (JMeq_eq H4)); clear H4; intros; subst.
+      clear H3. destruct (H _ _ H6); subst. pose (H10 := H0 _ H7); clearbody H10. 
+      rewrite H4, H10. replace e1 with e. replace Stml0 with Stml.
+      split; reflexivity. apply (j_tml_sem_fun _ _ _ j1 _ H8). apply UIP.
     + intros. eapply (j_q_union_sem _ _ _ _ _ _ _ (fun _ _ _ _ _ _ _ => _) _ H1). Unshelve.
       intros; simpl; subst. apply (existT_eq_elim H10); clear H10; intros; subst.
       clear H3 H2. apply (existT_eq_elim (JMeq_eq H5)); clear H5; intros; subst.
@@ -780,16 +352,16 @@ no, we can simplify *)
     + intros. inversion H. reflexivity.
     + intros. inversion H. reflexivity.
     + intros. inversion H. apply (existT_eq_elim H4); clear H4; intros; subst.
-      replace St0 with St. reflexivity. apply (Ev.j_tm_sem_fun _ _ _ j _ H2).
+      replace St0 with St. reflexivity. apply (j_tm_sem_fun _ _ _ j _ H2).
     + intros. inversion H. apply (existT_eq_elim H3); clear H3; intros; subst.
       apply (existT_eq_elim H5); clear H5; intros; subst. 
       replace e0 with (@eq_refl _ (length tml)).
       replace Stml0 with Stml. reflexivity.
-      apply (Ev.j_tml_sem_fun _ _ _ j _ H2). apply UIP.
+      apply (j_tml_sem_fun _ _ _ j _ H2). apply UIP.
     + intros. inversion H0. apply (existT_eq_elim H6); clear H6; intros; subst. clear H6.
       destruct (H _ _ H7). subst. rewrite H2.
       replace Stml0 with Stml. replace e'0 with e'. reflexivity.
-      apply UIP. apply (Ev.j_tml_sem_fun _ _ _ j _ H4).
+      apply UIP. apply (j_tml_sem_fun _ _ _ j _ H4).
     + intros. inversion H0. apply (existT_eq_elim H3); clear H3; intros; subst. clear H3.
       rewrite (H _ H4). reflexivity.
     + intros. inversion H1. apply (existT_eq_elim H5); clear H5; intros; subst.
@@ -806,10 +378,18 @@ no, we can simplify *)
       clear H11 H3. apply (existT_eq_elim (JMeq_eq H4)); clear H4; intros; subst.
       clear H3. destruct (H _ _ H6); subst. destruct (H0 _ _ H8); subst. intuition.
       rewrite H5. replace e with e1. reflexivity. apply UIP.
+    (* btbl *)
+    + intros. eapply (j_nil_btbl_sem _ _ _ _ _ _ H). Unshelve. simpl.
+      intros; simpl; subst. intuition.
+    + intros. eapply (j_cons_btbl_sem _ _ _ _ _ _ (fun _ _ _ _ _ _ => _) _ H1). Unshelve.
+      intros; simpl; subst. apply (existT_eq_elim H10); clear H10; intros; subst.
+      clear H9 H3. apply (existT_eq_elim (JMeq_eq H4)); clear H4; intros.
+      destruct (H _ _ H5); subst. destruct (H0 _ _ H7); subst; intuition.
+      clear H3. rewrite H6. replace e with e0. reflexivity. apply UIP.
     (* inner query *)
     + intros. eapply (j_iq_sel_sem _ _ _ _ _ _ _ (fun _ _ _ _ _ _ Ssel =>
         (fun h =>
-         let S1 := Sbtb h in
+         let S1 := Sbtbl h in
          let p := fun Vl => is_btrue (Sc (Ev.env_app G0 G (Ev.env_of_tuple G0 Vl) h)) in
          let S2 := Rel.sel S1 p in
          let f := fun Vl => Stml (Ev.env_app G0 G (Ev.env_of_tuple G0 Vl) h) in
@@ -818,7 +398,7 @@ no, we can simplify *)
       intros; simpl; subst. apply (existT_eq_elim H11); clear H11; intros; subst.
       clear H2 H3. destruct (H _ _ H4); subst. pose (H9 := H0 _ H7); clearbody H9. 
       rewrite H3, H9. replace Stml0 with Stml. reflexivity.
-      apply (Ev.j_tml_sem_fun _ _ _ j1 _ H8).
+      apply (j_tml_sem_fun _ _ _ j1 _ H8).
     + intros. eapply (j_iq_selstar_sem _ _ _ _ _ _ (fun _ _ _ _ _ _ => _) _ H1). Unshelve.
       intros; simpl; subst. apply (existT_eq_elim H9); clear H9; intros; subst.
       clear H2 H4. destruct (H _ _ H3); subst. pose (H7 := H0 _ H6); clearbody H7. 
@@ -844,18 +424,23 @@ no, we can simplify *)
     (forall G G' btb Sbtb, j_btb_sem d G G' btb Sbtb -> 
       forall G0 G0' btb0 Sbtb0, G = G0 -> btb = btb0 -> j_btb_sem d G0 G0' btb0 Sbtb0 -> 
       G' = G0' /\ Sbtb ~= Sbtb0) /\
+    (forall G G' btbl Sbtbl, j_btbl_sem d G G' btbl Sbtbl -> 
+      forall G0 G0' btbl0 Sbtbl0, G = G0 -> btbl = btbl0 -> j_btbl_sem d G0 G0' btbl0 Sbtbl0 -> 
+      G' = G0' /\ Sbtbl ~= Sbtbl0) /\
     (forall G q Sq, j_in_q_sem d G q Sq -> 
       forall G0 q0 Sq0, G = G0 -> q = q0 -> j_in_q_sem d G0 q0 Sq0 -> Sq ~= Sq0).
   Proof.
     intro. decompose [and] (j_sem_fun d). split.
-      intros. subst. apply (H _ _ _ _ H3 _ _ H7).
+      intros. subst. apply (H _ _ _ _ H4 _ _ H8).
     split.
-      intros. subst. apply (H1 _ _ _ _ H3 _ _ H7).
+      intros. subst. apply (H1 _ _ _ _ H4 _ _ H8).
     split.
-      intros. subst. apply (H0 _ _ _ H3 _ H7).
+      intros. subst. apply (H0 _ _ _ H4 _ H8).
     split.
-      intros. subst. apply (H2 _ _ _ _ H3 _ _ H7).
-    intros. subst. apply (H4 _ _ _ H3 _ H7).
+      intros. subst. apply (H2 _ _ _ _ H4 _ _ H8).
+    split.
+      intros. subst. apply (H3 _ _ _ _ H4 _ _ H8).
+    intros. subst. apply (H5 _ _ _ H4 _ H8).
   Qed.
 
   Corollary jT_sem_fun_dep : forall d G s T ST, j_tb_sem d G s T ST -> 

--- a/Semantics.v
+++ b/Semantics.v
@@ -1,12 +1,12 @@
 Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Syntax AbstractRelation Bool.Sumbool Tribool JMeq 
   FunctionalExtensionality ProofIrrelevance Eqdep_dec EqdepFacts Omega Util RelFacts Common Eval.
 
-Module SQLSemantics (Db : DB) (Sem: SEM Db) (Sql : SQL Db).
+Module SQLSemantics (Sem: SEM) (Sql : SQL).
   Import Db.
   Import Sem.
   Import Sql.
-  Module Ev := Evl Db.
-  Import Ev.
+(*  Module Ev := Evl Db. *)
+  Import Evl.
 
   Inductive j_tm_sem0 (G:Ctx) : pretm -> (env G -> Value) -> Prop :=
   | jts_const : forall c, j_tm_sem0 G (tmconst c) (fun _ => Db.c_sem c)
@@ -87,9 +87,9 @@ Module SQLSemantics (Db : DB) (Sem: SEM Db) (Sql : SQL Db).
       s = List.map snd tml ->
       j_q_sem d G s (select b tml btbl c) 
         (fun h => let S1 := Sbtbl h in
-                  let p  := fun Vl => Sem.is_btrue (Sc (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h)) in
+                  let p  := fun Vl => Sem.is_btrue (Sc (Evl.env_app _ _ (Evl.env_of_tuple G0 Vl) h)) in
                   let S2 := Rel.sel S1 p in
-                  let f  := fun Vl => Stml (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h) in
+                  let f  := fun Vl => Stml (Evl.env_app _ _ (Evl.env_of_tuple G0 Vl) h) in
                   let S := cast _ _ e (Rel.sum S2 f)
                   in if b then Rel.flat S else S)
   | jqs_selstar : forall G b btbl c,
@@ -100,9 +100,9 @@ Module SQLSemantics (Db : DB) (Sem: SEM Db) (Sql : SQL Db).
       s0 = List.concat G0 ->
       j_q_sem d G s0 (selstar b btbl c) 
         (fun h => let S1 := Sbtbl h in
-                  let p  := fun Vl => Sem.is_btrue (Sc (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h)) in
+                  let p  := fun Vl => Sem.is_btrue (Sc (Evl.env_app _ _ (Evl.env_of_tuple G0 Vl) h)) in
                   let S2 := Rel.sel S1 p in
-                  let f  := fun Vl => Stml (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h) in
+                  let f  := fun Vl => Stml (Evl.env_app _ _ (Evl.env_of_tuple G0 Vl) h) in
                   let S := cast _ _ e (Rel.sum S2 f)
                   in if b then Rel.flat S else S)
   | jqs_union : forall G b q1 q2,
@@ -184,9 +184,9 @@ Module SQLSemantics (Db : DB) (Sem: SEM Db) (Sql : SQL Db).
       j_btbl_sem d G (G1 ++ G0) (btb::btbl)
         (fun h =>
          let Rbtb := Sbtb h in
-         R_sum Rbtb (fun Vl => cast _ _ e (Rel.times (R_single Vl) (Sbtbl (Ev.env_app _ _ (Ev.env_of_tuple _ Vl) h)))))
+         R_sum Rbtb (fun Vl => cast _ _ e (Rel.times (R_single Vl) (Sbtbl (Evl.env_app _ _ (Evl.env_of_tuple _ Vl) h)))))
 (*         let Rbtbl := Sbtbl h in
-         R_sum Rbtbl (fun Vl => cast _ _ e (Rel.times (Sbtb (Ev.env_app _  _ (Ev.env_of_tuple _ Vl) h)) (R_single Vl))))
+         R_sum Rbtbl (fun Vl => cast _ _ e (Rel.times (Sbtb (Evl.env_app _  _ (Evl.env_of_tuple _ Vl) h)) (R_single Vl))))
 *)
   with j_in_q_sem (d : Db.D) : forall G, prequery -> (env G -> bool) -> Prop :=
   | jiqs_sel : forall G b tml btbl c,
@@ -196,9 +196,9 @@ Module SQLSemantics (Db : DB) (Sem: SEM Db) (Sql : SQL Db).
       j_tml_sem (G0++G) (List.map fst tml) Stml ->
       j_in_q_sem d G (select b tml btbl c) 
         (fun h => let S1 := Sbtbl h in
-                  let p  := fun Vl => Sem.is_btrue (Sc (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h)) in
+                  let p  := fun Vl => Sem.is_btrue (Sc (Evl.env_app _ _ (Evl.env_of_tuple G0 Vl) h)) in
                   let S2 := Rel.sel S1 p in
-                  let f  := fun Vl => Stml (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h) in
+                  let f  := fun Vl => Stml (Evl.env_app _ _ (Evl.env_of_tuple G0 Vl) h) in
                   let S := Rel.sum S2 f
                   in 0 <? Rel.card (if b then Rel.flat S else S))
   | jiqs_selstar : forall G b btbl c,
@@ -207,7 +207,7 @@ Module SQLSemantics (Db : DB) (Sem: SEM Db) (Sql : SQL Db).
       j_cond_sem d (G0++G) c Sc ->
       j_in_q_sem d G (selstar b btbl c) 
         (fun h => let S1 := Sbtbl h in
-                  let p  := fun Vl => Sem.is_btrue (Sc (Ev.env_app _ _ (Ev.env_of_tuple G0 Vl) h)) in
+                  let p  := fun Vl => Sem.is_btrue (Sc (Evl.env_app _ _ (Evl.env_of_tuple G0 Vl) h)) in
                   let S2 := Rel.sel S1 p in
 (*                  let f  := fun _ => Vector.nil Rel.V) in
                   let S := cast _ _ e (Rel.sum S2 f) 
@@ -259,12 +259,12 @@ no, we can simplify *)
   Lemma j_nil_btb_sem :
     forall d G G' Snil (P : Prop),
        (forall (G0 G0': Ctx), G0 = G -> G0' = G' -> List.nil = G0' ->
-        (fun (_:Ev.env G) => Rel.Rone) ~= Snil -> P) ->
+        (fun (_:Evl.env G) => Rel.Rone) ~= Snil -> P) ->
        j_btb_sem d G G' List.nil Snil -> P.
   Proof.
     intros.
     enough (forall G0 G0' (btb0 : list (pretb * Scm)) 
-      (Snil0 : Ev.env G0 -> Rel.R (list_sum (List.map (length (A:=Name)) G0'))), 
+      (Snil0 : Evl.env G0 -> Rel.R (list_sum (List.map (length (A:=Name)) G0'))), 
         j_btb_sem d G0 G0' btb0 Snil0 ->
         G0 = G -> G0' = G' -> List.nil = btb0 -> Snil0 ~= Snil -> P).
     apply (H1 _ _ _ _ H0 eq_refl eq_refl eq_refl JMeq_refl).
@@ -276,12 +276,12 @@ no, we can simplify *)
   Lemma j_nil_btbl_sem :
     forall d G G' Snil (P : Prop),
        (forall (G0 G0': Ctx), G0 = G -> G0' = G' -> List.nil = G0' ->
-        (fun (_:Ev.env G) => Rel.Rone) ~= Snil -> P) ->
+        (fun (_:Evl.env G) => Rel.Rone) ~= Snil -> P) ->
        j_btbl_sem d G G' List.nil Snil -> P.
   Proof.
     intros.
     enough (forall G0 G0' btbl0
-      (Snil0 : Ev.env G0 -> Rel.R (list_sum (List.map (length (A:=Name)) G0'))), 
+      (Snil0 : Evl.env G0 -> Rel.R (list_sum (List.map (length (A:=Name)) G0'))), 
         j_btbl_sem d G0 G0' btbl0 Snil0 ->
         G0 = G -> G0' = G' -> List.nil = btbl0 -> Snil0 ~= Snil -> P).
     apply (H1 _ _ _ _ H0 eq_refl eq_refl eq_refl JMeq_refl).
@@ -307,9 +307,9 @@ no, we can simplify *)
       eapply (j_q_sel_sem _ _ _ _ _ _ _ _ (fun _ _ s1 _ _ _ _ Ssel =>
         _ = s1 /\ (fun h =>
         let S1 := Sbtbl h in
-        let p := fun Vl => is_btrue (Sc (Ev.env_app G0 G (Ev.env_of_tuple G0 Vl) h)) in
+        let p := fun Vl => is_btrue (Sc (Evl.env_app G0 G (Evl.env_of_tuple G0 Vl) h)) in
         let S2 := Rel.sel S1 p in
-        let f := fun Vl => Stml (Ev.env_app G0 G (Ev.env_of_tuple G0 Vl) h) in
+        let f := fun Vl => Stml (Evl.env_app G0 G (Evl.env_of_tuple G0 Vl) h) in
         let S := cast _ _ e (Rel.sum S2 f) in
         if b then Rel.flat S else S) ~= Ssel) _ H1). Unshelve.
       intros; simpl; subst. apply (existT_eq_elim H13); clear H13; intros; subst.
@@ -390,9 +390,9 @@ no, we can simplify *)
     + intros. eapply (j_iq_sel_sem _ _ _ _ _ _ _ (fun _ _ _ _ _ _ Ssel =>
         (fun h =>
          let S1 := Sbtbl h in
-         let p := fun Vl => is_btrue (Sc (Ev.env_app G0 G (Ev.env_of_tuple G0 Vl) h)) in
+         let p := fun Vl => is_btrue (Sc (Evl.env_app G0 G (Evl.env_of_tuple G0 Vl) h)) in
          let S2 := Rel.sel S1 p in
-         let f := fun Vl => Stml (Ev.env_app G0 G (Ev.env_of_tuple G0 Vl) h) in
+         let f := fun Vl => Stml (Evl.env_app G0 G (Evl.env_of_tuple G0 Vl) h) in
          let S := Rel.sum S2 f in 
          0 <? Rel.card (if b then Rel.flat S else S)) ~= Ssel) _ H1). Unshelve.
       intros; simpl; subst. apply (existT_eq_elim H11); clear H11; intros; subst.

--- a/Semantics.v
+++ b/Semantics.v
@@ -125,6 +125,10 @@ Module SQLSemantics (Sem: SEM) (Sql : SQL).
       forall St,
       j_tm_sem G t St ->
       j_cond_sem d G (cndnull b t) (fun Vl => of_bool (match St Vl with None => b | _ => negb b end))
+  | jcs_istrue : forall G c,
+      forall Sc,
+      j_cond_sem d G c Sc ->
+      j_cond_sem d G (cndistrue c) (fun Vl => of_bool (Sem.is_btrue (Sc Vl)))
   | jcs_pred : forall G n p tml,
       forall Stml e,
       j_tml_sem G tml Stml ->
@@ -175,13 +179,6 @@ Module SQLSemantics (Sem: SEM) (Sql : SQL).
         (fun h =>
          let Rbtb := Sbtb h in
          Rel.rsum Rbtb (fun Vl => cast _ _ e (Rel.times (Sbtbl (Evl.env_app _ _ (Evl.env_of_tuple _ Vl) h)) (Rel.Rsingle Vl))))
-(*
-         let Rbtb := Sbtb h in
-         R_sum Rbtb (fun Vl => cast _ _ e (Rel.times (R_single Vl) (Sbtbl (Evl.env_app _ _ (Evl.env_of_tuple _ Vl) h)))))
-*)
-(*         let Rbtbl := Sbtbl h in
-         R_sum Rbtbl (fun Vl => cast _ _ e (Rel.times (Sbtb (Evl.env_app _  _ (Evl.env_of_tuple _ Vl) h)) (R_single Vl))))
-*)
   with j_in_q_sem (d : Db.D) : forall G, prequery -> (env G -> bool) -> Prop :=
   | jiqs_sel : forall G b tml btbl c,
       forall G0 Sbtbl Sc Stml,
@@ -347,6 +344,8 @@ no, we can simplify *)
     + intros. inversion H. reflexivity.
     + intros. inversion H. apply (existT_eq_elim H4); clear H4; intros; subst.
       replace St0 with St. reflexivity. apply (j_tm_sem_fun _ _ _ j _ H2).
+    + intros. inversion H0. apply (existT_eq_elim H3); clear H3; intros; subst.
+      rewrite (H _ H4). reflexivity.
     + intros. inversion H. apply (existT_eq_elim H3); clear H3; intros; subst.
       apply (existT_eq_elim H5); clear H5; intros; subst. 
       replace e0 with (@eq_refl _ (length tml)).

--- a/Syntax.v
+++ b/Syntax.v
@@ -27,6 +27,7 @@ Module Type SQL.
   | cndtrue   : precond
   | cndfalse  : precond
   | cndnull   : bool -> pretm -> precond
+  | cndistrue : precond -> precond
   | cndpred   : forall n, (forall l : list BaseConst, length l = n -> bool) -> list pretm -> precond
   | cndmemb   : bool -> list pretm -> prequery -> precond
   | cndex     : prequery -> precond
@@ -131,6 +132,7 @@ Module Type SQL.
   | j_cndtrue   : forall g, j_db d -> j_cond d g cndtrue
   | j_cndfalse  : forall g, j_db d -> j_cond d g cndfalse
   | j_cndnull   : forall g t b, j_db d -> j_tm g t -> j_cond d g (cndnull b t)
+  | j_cndistrue : forall g c, j_cond d g c -> j_cond d g (cndistrue c)
   | j_cndpred   : forall g n p tml, j_db d -> j_tml g tml -> length tml = n -> j_cond d g (cndpred n p tml)
   | j_cndmemb   : forall g q sq tl b, 
                   j_tml g tl -> j_query d g q sq -> 
@@ -237,7 +239,7 @@ Module Type SQL.
           (fun G0 btb G1 H0 => btb_schema d btb = G1)
           (fun G0 btbl G1 H0 => btbl_schema d btbl = G1)
           (fun G0 Q0 H0 => exists s0, q_schema d Q0 true = s0)
-          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ HWF).
+          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ HWF).
   Unshelve.
   + intros s0 c b btm btb G0 G1 Hbtb IHbtb Hc IHc Html. simpl. intro. rewrite e. reflexivity.
   + intros G0 btbl G1 c s0 b Hbtbl IHbtbl Hc IHc e Html. simpl.
@@ -251,6 +253,7 @@ Module Type SQL.
   + intros G0 Hdb. reflexivity.
   + intros G0 Hdb. reflexivity.
   + intros G0 t b Hdb Ht. reflexivity.
+  + intros; constructor.
   + intros; constructor.
   + intros; constructor.
   + intros; constructor.

--- a/Syntax.v
+++ b/Syntax.v
@@ -1,99 +1,4 @@
-Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat AbstractRelation Tribool.
-
-Definition ret {A} : A -> option A := Some.
-Definition bind {A B} : option A -> (A -> option B) -> option B :=
-  fun a f => match a with None => None | Some x => f x end.
-Definition monadic_map {A B} (f : A -> option B) (l : list A) : option (list B) :=
-  List.fold_right (fun a mbl => 
-    bind mbl (fun bl => 
-    bind (f a) (fun b => 
-    ret (b::bl))))
-  (ret List.nil) l.
-
-Lemma length_monadic_map (A B: Type) (f : A -> option B) (l1 : list A) :
-  forall l2, monadic_map f l1 = Some l2 -> List.length l1 = List.length l2.
-elim l1.
-+ intro. simpl. unfold ret. intro. injection H. intro. subst. auto.
-+ simpl. intros a l. case (monadic_map f l).
-  - simpl. case (f a).
-    * simpl. unfold ret. intros b l0 IH l2 Hl2. injection Hl2. intro H.
-      subst. simpl. apply f_equal. apply IH. reflexivity.
-    * simpl. intros. discriminate.
-  - simpl. intros. discriminate.
-Qed.
-
-Lemma bind_elim (A B : Type) (x : option A) (f : A -> option B) (P : option B -> Prop) :
-  (forall y, x = Some y -> P (f y)) -> (x = None -> P None) ->
-  P (bind x f).
-intros. destruct x eqn:e; simpl; auto.
-Qed.
-
-Lemma length_to_list (A : Type) (n : nat) (v : Vector.t A n) : length (to_list v) = n.
-elim v. auto.
-intros. transitivity (S (length (to_list t ))); auto.
-Qed.
-
-Definition vec_monadic_map {A B n} (f : A -> option B) (v : Vector.t A n) : option (Vector.t B n).
-Proof.
-  destruct (monadic_map f (Vector.to_list v)) eqn:e.
-  + refine (Some (cast (of_list l) _)).
-    refine (let Hlen := length_monadic_map _ _ _ _ _ e in _).
-    rewrite <- Hlen.
-    apply length_to_list.
-  + apply None.
-Qed.
-
-Module Type DB.
-  Parameter Name : Type.
-  Hypothesis Name_dec : forall x y:Name, {x = y} + {x <> y}. 
-  Definition FullName := (Name * Name)%type.
-  Definition FullVar  := (nat * Name)%type.
-  Definition Scm      := list Name.         (* schema (attribute names for a relation) *)
-  Definition Ctx      := list Scm.          (* context (domain of an environment) = list of lists of names *)
-
-  Parameter BaseConst : Type.
-  Definition Value    := option BaseConst.
-  Definition null     : Value := None.
-  Definition c_sem     : BaseConst -> Value := Some.    (* semantics of constants *)
-
-  Declare Module Rel  : REL with Definition V := Value.
-
-  Parameter D         : Type.
-  Variable db_schema  : D -> Name -> option (list Name).
-  Hypothesis db_rel   : forall d n xl, db_schema d n = Some xl -> Rel.R (List.length xl).
-  Implicit Arguments db_rel [d n xl].
-
-  Lemma Scm_dec (s1 s2 : Scm) : {s1 = s2} + {s1 <> s2}.
-    exact (list_eq_dec Name_dec s1 s2).
-  Qed.
-
-  Definition Scm_eq : Scm -> Scm -> bool := 
-    fun s1 s2 => match Scm_dec s1 s2 with left _ => true | right _ => false end.
-
-  Lemma Scm_eq_elim (P : bool -> Prop) (s s' : Scm) (Htrue : s = s' -> P true) (Hfalse : s <> s' -> P false)
-  : P (Scm_eq s s').
-  unfold Scm_eq. destruct (Scm_dec s s') eqn:e. all: auto.
-  Qed.
-
-
-  Lemma FullName_dec (A B : FullName) : {A = B} + {A <> B}.
-    elim A; intros A1 A2.
-    elim B; intros B1 B2.
-    elim (Name_dec A1 B1); intro H1.
-    + elim (Name_dec A2 B2); intro H2.
-      - subst. left. reflexivity.
-      - right. intro. injection H. intro. contradiction H2.
-    + right. intro. injection H. intros _ H2. contradiction H1.
-  Qed.
-
-  Definition FullName_eq : FullName -> FullName -> bool :=
-    fun A B => match FullName_dec A B with left _ => true | right _ => false end.
-
-  Parameter c_eq : BaseConst -> BaseConst -> bool.
-  Hypothesis BaseConst_dec : forall (c1 c2 : BaseConst), { c1 = c2 } + { c1 <> c2 }.
-  Hypothesis BaseConst_eqb_eq : forall (c1 c2 : BaseConst), c_eq c1 c2 = true <-> c1 = c2.
-
-End DB.
+Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat AbstractRelation Tribool Common Util.
 
 Module Type SQL (Db : DB).
   Import Db.
@@ -112,8 +17,8 @@ Module Type SQL (Db : DB).
   Qed.
 
   Inductive prequery : Type :=
-  | select  : bool -> list (pretm * Name) -> list (pretb * Scm) -> precond -> prequery
-  | selstar : bool -> list (pretb * Scm) -> precond -> prequery
+  | select  : bool -> list (pretm * Name) -> list (list (pretb * Scm)) -> precond -> prequery
+  | selstar : bool -> list (list (pretb * Scm)) -> precond -> prequery
   | qunion  : bool -> prequery -> prequery -> prequery
   | qinters : bool -> prequery -> prequery -> prequery
   | qexcept : bool -> prequery -> prequery -> prequery
@@ -170,6 +75,14 @@ Module Type SQL (Db : DB).
   Definition tmlist_of_ctx (G: Ctx) : list pretm := 
     List.concat (mapi (fun i => List.map (fun x => tmvar (i,x))) G).
 
+  Lemma length_tmlist c0 : length (tmlist_of_ctx c0) = length (concat c0).
+  Proof.
+    unfold tmlist_of_ctx. unfold mapi. generalize 0.
+    elim c0; intuition. 
+    simpl. do 2 rewrite app_length. rewrite cmap_length.
+    f_equal. apply H.
+  Qed.
+
   Inductive j_var (a : Name) : Scm -> Prop :=
   | j_varhd   : forall s, ~ List.In a s -> j_var a (a::s)
   | j_varcons : forall b s, a <> b -> j_var a s -> j_var a (b::s).
@@ -189,25 +102,26 @@ Module Type SQL (Db : DB).
 
   Inductive j_query (d : Db.D) : Ctx -> prequery -> Scm -> Prop :=
   | j_select :
-      forall s c b btm btb g g1,
-      j_btb d g btb g1 ->       (* btb is wellformed under Ctx g, producing a context extension g1 *)
+      forall s c b btm btbl g g1,
+      j_btbl d g btbl g1 ->     (* btbl is wellformed under Ctx g, producing a context extension g1 *)
       j_cond d (g1 ++ g) c ->   (* c is defined under Ctx (g1 ++ g) *)
       j_tml (g1 ++ g) (List.map fst btm) -> (* the attr names given don't matter *)
       (* j_tm/j_cond needs all of the references to be unambiguous, i.e. if (g1 ++ g) contains duplicate entries,
           they cannot be used by the terms *)
       s = List.map snd btm ->   (* the schema is given by the second components of btm *)
-      j_query d g (select b btm btb c) s
+      j_query d g (select b btm btbl c) s
   | j_selstar :
-      forall g btb g1 c s b,
-      j_btb d g btb g1 ->       (* btb is wellformed under Ctx g, producing a context extension g1 *)
+      forall g btbl g1 c s b,
+      j_btbl d g btbl g1 ->       (* btb is wellformed under Ctx g, producing a context extension g1 *)
       j_cond d (g1 ++ g) c ->   (* c is defined under Ctx (g1 ++ g) *)
       s = List.concat g1 ->     (* merges the schemas in g1 *)
       j_tml (g1 ++ g) (tmlist_of_ctx g1) ->
       (* the line above forces the attributes in g1 to be unambiguous *)
-      j_query d g (selstar b btb c) s
-  | j_union   : forall g b q1 q2 s, j_query d g q1 s -> j_query d g q2 s -> j_query d g (qunion b q1 q2) s
-  | j_inters  : forall g b q1 q2 s, j_query d g q1 s -> j_query d g q2 s -> j_query d g (qinters b q1 q2) s
-  | j_except  : forall g b q1 q2 s, j_query d g q1 s -> j_query d g q2 s -> j_query d g (qexcept b q1 q2) s
+      j_query d g (selstar b btbl c) s
+  (* union etc. allow different schemas for subqueries, and return the schema of the first query *)
+  | j_union   : forall g b q1 q2 s s', length s = length s' -> j_query d g q1 s -> j_query d g q2 s' -> j_query d g (qunion b q1 q2) s
+  | j_inters  : forall g b q1 q2 s s', length s = length s' -> j_query d g q1 s -> j_query d g q2 s' -> j_query d g (qinters b q1 q2) s
+  | j_except  : forall g b q1 q2 s s', length s = length s' -> j_query d g q1 s -> j_query d g q2 s' -> j_query d g (qexcept b q1 q2) s
 
   with j_tb (d : Db.D) : Ctx -> pretb -> Scm -> Prop :=
   | j_tbbase  : forall x s g, j_db d -> Db.db_schema d x = Some s -> j_tb d g (tbbase x) s
@@ -232,28 +146,34 @@ Module Type SQL (Db : DB).
   | j_btbcons : forall g T s s' btb g1, length s = length s' -> List.NoDup s' -> 
                 j_tb d g T s -> j_btb d g btb g1 -> j_btb d g ((T,s')::btb) (s'::g1)
 
+  with j_btbl (d : Db.D) : Ctx -> list (list (pretb * Scm)) -> Ctx -> Prop :=
+  | j_btblnil : forall g, j_db d -> j_btbl d g List.nil List.nil
+  | j_btblcons : forall g B Bl g1 g2, j_btbl d g Bl g1 -> j_btb d (g1++g) B g2 -> j_btbl d g (B::Bl) (g2++g1)
+ 
   with j_inquery (d : Db.D) : Ctx -> prequery -> Prop :=
   | j_inselect :
-      forall c b btm btb g g1,
-      j_btb d g btb g1 ->       (* btb is wellformed under Ctx g, producing a context extension g1 *)
+      forall c b btm btbl g g1,
+      j_btbl d g btbl g1 ->       (* btb is wellformed under Ctx g, producing a context extension g1 *)
       j_cond d (g1 ++ g) c ->  (* c is defined under Ctx (g (+) g1) *)
       j_tml (g1 ++ g) (List.map fst btm) -> (* btm is wellformed under Ctx (g (+) g1) *)
-      j_inquery d g (select b btm btb c)
+      j_inquery d g (select b btm btbl c)
   | j_inselstar :
-      forall g btb g1 c b,
-      j_btb d g btb g1 ->       (* btb is wellformed under Ctx g, producing a context extension g1 *)
+      forall g btbl g1 c b,
+      j_btbl d g btbl g1 ->       (* btb is wellformed under Ctx g, producing a context extension g1 *)
       j_cond d (g1 ++ g) c ->  (* c is defined under Ctx (g (+) g1) *)
       (* the different behaviour, compared with j_query, is achieved by omitting the j_tml premise *)
-      j_inquery d g (selstar b btb c)
-  | j_inunion   : forall g b q1 q2 s, j_query d g q1 s -> j_query d g q2 s -> j_inquery d g (qunion b q1 q2)
-  | j_ininters  : forall g b q1 q2 s, j_query d g q1 s -> j_query d g q2 s -> j_inquery d g (qinters b q1 q2)
-  | j_inexcept  : forall g b q1 q2 s, j_query d g q1 s -> j_query d g q2 s -> j_inquery d g (qexcept b q1 q2)
+      j_inquery d g (selstar b btbl c)
+  (* union etc. allow different schemas for subqueries, and return the schema of the first query *)
+  | j_inunion   : forall g b q1 q2 s s', length s = length s' -> j_query d g q1 s -> j_query d g q2 s' -> j_inquery d g (qunion b q1 q2)
+  | j_ininters  : forall g b q1 q2 s s', length s = length s' -> j_query d g q1 s -> j_query d g q2 s' -> j_inquery d g (qinters b q1 q2)
+  | j_inexcept  : forall g b q1 q2 s s', length s = length s' -> j_query d g q1 s -> j_query d g q2 s' -> j_inquery d g (qexcept b q1 q2)
   .
 
   Scheme jq_ind_mut := Induction for j_query Sort Prop
   with jT_ind_mut := Induction for j_tb Sort Prop
   with jc_ind_mut := Induction for j_cond Sort Prop
   with jbT_ind_mut := Induction for j_btb Sort Prop
+  with jbTl_ind_mut := Induction for j_btbl Sort Prop
   with jiq_ind_mut := Induction for j_inquery Sort Prop.
 
   Combined Scheme j_ind_mut from jq_ind_mut, jT_ind_mut, jc_ind_mut, jbT_ind_mut, jiq_ind_mut.
@@ -267,35 +187,28 @@ Module Type SQL (Db : DB).
   (* a recursive definition of schemas *)
 
   (* XXX: not entirely sure of the rationale for propagating or erasing the boolean b *)
-  Fixpoint q_schema (d : Db.D) (q : prequery) (b : bool) {struct q} : option (list Name) :=
+  Fixpoint q_schema (d : Db.D) (q : prequery) (b : bool) {struct q} : list Name :=
     match q with
-    | select _ btm _ _  => ret (List.map snd btm) (* XXX: no duplicate-freedom check *)
+    | select _ btm _ _  => List.map snd btm (* XXX: no duplicate-freedom check *)
     | selstar _ btb _   =>
-        if b then ret List.nil
-        else ret (List.concat (List.map snd btb))
+        if b then List.nil
+        else List.concat (List.concat ((List.map (List.map snd) btb)))
      (* bind (monadic_map (tb_schema d) btb) (fun G0 => ret (List.concat G0)) *)
-    | qunion _ q1 q2    =>
-        bind (q_schema d q1 false) (fun sq1 =>
-        bind (q_schema d q2 false) (fun sq2 =>
-          if (Scm_eq sq1 sq2) then ret sq1 else None))
-    | qinters _ q1 q2   =>
-        bind (q_schema d q1 false) (fun sq1 =>
-        bind (q_schema d q2 false) (fun sq2 =>
-          if (Scm_eq sq1 sq2) then ret sq1 else None))
-    | qexcept _ q1 q2   => 
-        bind (q_schema d q1 false) (fun sq1 =>
-        bind (q_schema d q2 false) (fun sq2 =>
-          if (Scm_eq sq1 sq2) then ret sq1 else None))
-    end
-  with tb_schema (d : Db.D) (T : pretb) {struct T} : option (list Name) :=
+    | qunion _ q1 _ => q_schema d q1 false
+    | qinters _ q1 q2   => q_schema d q1 false
+    | qexcept _ q1 q2   => q_schema d q1 false
+    end.
+
+  Definition tb_schema (d : Db.D) (T : pretb) : option (list Name) :=
     match T with
     | tbbase x  => Db.db_schema d x
-    | tbquery q0 => q_schema d q0 false
-    end
-  with pred_safe (d : Db.D) (c : precond) {struct c} : bool :=
+    | tbquery q0 => ret (q_schema d q0 false)
+    end.
+
+(* 
+  Fixpoint pred_safe (d : Db.D) (c : precond) {struct c} : bool :=
     match c with
-    | cndmemb _ tl q0 => 
-        match (q_schema d q0 false) with Some sq0 => List.length sq0 =? List.length tl | _ => false end
+    | cndmemb _ tl q0 => List.length (q_schema d q0 false) =? List.length tl
     | cndex q0 => match q_schema d q0 true with None => false | _ => true end
     | cndand c1 c2 => pred_safe d c1 && pred_safe d c2
     | cndor c1 c2 => pred_safe d c1 && pred_safe d c2
@@ -303,55 +216,59 @@ Module Type SQL (Db : DB).
     | cndpred n p tml => length tml =? n
     | _ => true
     end.
+*)
 
-  Definition btb_schema (d : Db.D) (btb : list (pretb * Scm)) : option Ctx :=
+  Definition btb_schema (d : Db.D) : list (pretb * Scm) -> Ctx :=
     (* bind (monadic_map (tb_schema d) btb) ret *)
-    ret (List.map snd btb).
+    List.map snd.
+
+  Definition btbl_schema (d : Db.D) (btbl : list (list (pretb * Scm))) : Ctx :=
+    List.concat (List.map (btb_schema d) btbl).
+
+(* TODO we stop here because we still have to do btbl_schema *)
 
   Theorem jq_q_schema : forall d G Q s,
-    forall j : j_query d G Q s, q_schema d Q false = Some s.
+    forall j : j_query d G Q s, q_schema d Q false = s.
   intros d G Q s HWF.
   eapply (jq_ind_mut _ 
-          (fun G0 Q0 s0 H0 => q_schema d Q0 false = Some s0)
-          (fun G0 T0 s0 H0 => tb_schema d T0 = Some s0)
-          (fun G0 c0 H0 => pred_safe d c0 = true)
-          (fun G0 btb G1 H0 => btb_schema d btb = Some G1)
-          (fun G0 Q0 H0 => exists s0, q_schema d Q0 true = Some s0)
-          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ HWF).
+          (fun G0 Q0 s0 H0 => q_schema d Q0 false = s0)
+          (fun G0 T0 s0 H0 => (* tb_schema d T0 = Some s0 *) True)
+          (fun G0 c0 H0 => (* pred_safe d c0 = true *) True)
+          (fun G0 btb G1 H0 => btb_schema d btb = G1)
+          (fun G0 btbl G1 H0 => btbl_schema d btbl = G1)
+          (fun G0 Q0 H0 => exists s0, q_schema d Q0 true = s0)
+          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ HWF).
   Unshelve.
   + intros s0 c b btm btb G0 G1 Hbtb IHbtb Hc IHc Html. simpl. intro. rewrite e. reflexivity.
-  + intros G0 btb G1 c s0 b Hbtb IHbtb Hc IHc e Html. simpl. 
-    simpl in IHbtb. unfold btb_schema, ret in IHbtb. injection IHbtb. clear IHbtb; intro IHbtb.
-    rewrite e. rewrite IHbtb. reflexivity.
-  + intros G0 b Q1 Q2 s0 HQ1 IHQ1 HQ2 IHQ2; simpl; rewrite IHQ1, IHQ2; simpl; apply Scm_eq_elim; intro H;
-    [ reflexivity | contradiction H; reflexivity ].
-  + intros G0 b Q1 Q2 s0 HQ1 IHQ1 HQ2 IHQ2; simpl; rewrite IHQ1, IHQ2; simpl; apply Scm_eq_elim; intro H;
-    [ reflexivity | contradiction H; reflexivity ].
-  + intros G0 b Q1 Q2 s0 HQ1 IHQ1 HQ2 IHQ2; simpl; rewrite IHQ1, IHQ2; simpl; apply Scm_eq_elim; intro H;
-    [ reflexivity | contradiction H; reflexivity ].
-  + intros x s0 G0 Hdb e. simpl. exact e.
-  + intros x s0 G0 Hdb e. simpl. exact e.
+  + intros G0 btbl G1 c s0 b Hbtbl IHbtbl Hc IHc e Html. simpl.
+    simpl in IHbtbl. unfold btbl_schema, btb_schema in IHbtbl.
+    rewrite e. rewrite <- IHbtbl. reflexivity.
+  + intros G0 b Q1 Q2 s0 s1 Hlen HQ1 IHQ1 HQ2 IHQ2; simpl; simpl in IHQ1; exact IHQ1.
+  + intros G0 b Q1 Q2 s0 s1 Hlen HQ1 IHQ1 HQ2 IHQ2; simpl; simpl in IHQ1; exact IHQ1.
+  + intros G0 b Q1 Q2 s0 s1 Hlen HQ1 IHQ1 HQ2 IHQ2; simpl; simpl in IHQ1; exact IHQ1.
+  + intros x s0 G0 Hdb e. simpl. constructor.
+  + intros x s0 G0 Hdb e. simpl. constructor.
   + intros G0 Hdb. reflexivity.
   + intros G0 Hdb. reflexivity.
   + intros G0 t b Hdb Ht. reflexivity.
-  + intros G0 n p tml Hdb Html e. simpl. apply Nat.eqb_eq. exact e.
-  + intros G0 Q0 sQ tl b Html HQ0 IHQ0 e. simpl. rewrite IHQ0. apply Nat.eqb_eq. exact e.
-  + intros G0 Q0 HQ0 IHQ0. simpl. destruct IHQ0. rewrite H. reflexivity.
-  + intros G0 c1 c2 Hc1 IHc1 Hc2 IHc2. simpl. rewrite IHc1, IHc2. reflexivity.
-  + intros G0 c1 c2 Hc1 IHc1 Hc2 IHc2. simpl. rewrite IHc1, IHc2. reflexivity.
-  + intros G0 c0 Hc0 IHc0. simpl. rewrite IHc0. reflexivity.
-  + intros G0 Hdb. reflexivity.
-  + intros G0 T s0 s' btb G1 Hlen Hnodup HT IHT Hbtb IHbtb. simpl. unfold btb_schema. simpl.
-    simpl in IHbtb. unfold btb_schema, ret in IHbtb. injection IHbtb. clear IHbtb; intro IHbtb.
+  + intros; constructor.
+  + intros; constructor.
+  + intros; constructor.
+  + intros; constructor.
+  + intros; constructor.
+  + intros; constructor.
+  + intros; constructor.
+  + intros G0 T s0 s' btb G1 Hlen Hnodup HT IHT Hbtb IHbtb. simpl. unfold btb_schema.
+    simpl in IHbtb. unfold btb_schema, ret in IHbtb.
     rewrite IHbtb. reflexivity.
+  + intros; reflexivity.
+  + intros G1 btb btbl G2 G3 Hbtbl IHbtbl Hbtb IHbtb. simpl.
+    simpl in IHbtbl, IHbtb. rewrite <- IHbtbl, <- IHbtb. reflexivity.
   + intros c b btm btb G0 G1 Hbtb IHbtb Hc IHc Html. simpl. eexists. all:auto.
   + intros G0 btb G1 c b Hbtb IHbtb Hc IHc. simpl. eexists. all:eauto.
-  + intros G0 b Q1 Q2 s0 HQ1 IHQ1 HQ2 IHQ2; simpl; rewrite IHQ1, IHQ2; simpl; 
-    exists s0; apply Scm_eq_elim; intro H; [ reflexivity | contradiction H; reflexivity ].
-  + intros G0 b Q1 Q2 s0 HQ1 IHQ1 HQ2 IHQ2; simpl; rewrite IHQ1, IHQ2; simpl; 
-    exists s0; apply Scm_eq_elim; intro H; [ reflexivity | contradiction H; reflexivity ].
-  + intros G0 b Q1 Q2 s0 HQ1 IHQ1 HQ2 IHQ2; simpl; rewrite IHQ1, IHQ2; simpl; 
-    exists s0; apply Scm_eq_elim; intro H; [ reflexivity | contradiction H; reflexivity ].
+  + intros G0 b Q1 Q2 s0 s1 Hlen HQ1 IHQ1 HQ2 IHQ2; simpl. rewrite IHQ1. exists s0; auto.
+  + intros G0 b Q1 Q2 s0 s1 Hlen HQ1 IHQ1 HQ2 IHQ2; simpl. rewrite IHQ1. exists s0; auto.
+  + intros G0 b Q1 Q2 s0 s1 Hlen HQ1 IHQ1 HQ2 IHQ2; simpl. rewrite IHQ1. exists s0; auto.
   Qed.
 
   Definition tm_lift (t : pretm) k :=

--- a/Syntax.v
+++ b/Syntax.v
@@ -1,6 +1,6 @@
 Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat AbstractRelation Tribool Common Util.
 
-Module Type SQL (Db : DB).
+Module Type SQL.
   Import Db.
 
   (* I will probably need to declare a canonical structure/type class for Names *)

--- a/Translation2V.v
+++ b/Translation2V.v
@@ -6,7 +6,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
   Import Sql.
 
   Module RF := RelFacts.Facts Db Sql.
-  Module SF := SemFacts.Facts Db Sql.
+  Module SF := SemFacts.Facts Db.
   Import RF.
   Import SF.
 

--- a/Translation2V.v
+++ b/Translation2V.v
@@ -1,20 +1,20 @@
 Require Import Eqdep Lists.List Lists.ListSet Vector Arith.PeanoNat Syntax AbstractRelation Bool.Sumbool Tribool 
-  Semantics JMeq FunctionalExtensionality Omega Coq.Init.Specif ProofIrrelevance EqdepFacts Util RelFacts SemFacts.
+  Semantics JMeq FunctionalExtensionality Omega Coq.Init.Specif ProofIrrelevance EqdepFacts Util RelFacts SemFacts Common Eval.
 
-Module Translation2V (Db : DB) (Sql : SQL Db).
+Module Translation2V (Sql : SQL).
   Import Db.
   Import Sql.
 
-  Module RF := RelFacts.Facts Db Sql.
-  Module SF := SemFacts.Facts Db.
+  Module RF := RelFacts.Facts Sql.
+  Module SF := SemFacts.Facts.
   Import RF.
   Import SF.
 
-  Module S2 := Sem2 Db.
-  Module S3 := Sem3 Db.
-  Module Ev := Evl Db Sql.
-  Module SQLSem2 := SQLSemantics Db S2 Sql Ev.
-  Module SQLSem3 := SQLSemantics Db S3 Sql Ev.
+  Module S2 := Sem2.
+  Module S3 := Sem3.
+  Module Ev := Evl.
+  Module SQLSem2 := SQLSemantics S2 Sql.
+  Module SQLSem3 := SQLSemantics S3 Sql.
 
   (* just some trivial operations on names *)
   (* they will be moved to a separate module of names, which we may then assume *)
@@ -33,7 +33,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     | cndmemb true tl Q => cndmemb true tl (ttquery d Q)
     | cndmemb false tl Q => 
         let al := freshlist (length tl) in
-          cndnot (cndex (selstar false (List.cons (tbquery (ttquery d Q), al) List.nil)
+          cndnot (cndex (selstar false (((tbquery (ttquery d Q), al)::List.nil)::List.nil)
             (List.fold_right (fun (ta : pretm * Name) acc =>
               let (t,a) := ta in
               cndand (cndor (cndnull true (tmvar (0,a))) (cndor (cndnull true (tm_lift t 1)) (cndeq (tm_lift t 1) (tmvar (0,a))))) acc)
@@ -54,7 +54,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
           (List.fold_right (fun t acc => cndand (cndnull false t) acc) cndtrue tml)
     | cndmemb true tl Q => 
         let al := freshlist (length tl) in
-          cndnot (cndex (selstar false (List.cons (tbquery (ttquery d Q), al) List.nil)
+          cndnot (cndex (selstar false (((tbquery (ttquery d Q), al)::List.nil)::List.nil)
             (List.fold_right (fun (ta : pretm * Name) acc =>
               let (t,a) := ta in
               cndand (cndor (cndnull true (tmvar (0,a))) (cndor (cndnull true (tm_lift t 1)) (cndeq (tm_lift t 1) (tmvar (0,a))))) acc)
@@ -67,8 +67,14 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     end
   with ttquery (d: Db.D) (Q : prequery) : prequery :=
     match Q with
-    | select b btm btb c => select b btm (List.map (fun bt => (tttable d (fst bt), snd bt)) btb) (ttcond d c)
-    | selstar b btb c => selstar b (List.map (fun bt => (tttable d (fst bt), snd bt)) btb) (ttcond d c)
+    | select b btm btbl c => 
+        select b btm (List.map (fun btb => 
+          List.map (fun bt => (tttable d (fst bt), snd bt)) btb) btbl) 
+        (ttcond d c)
+    | selstar b btbl c => 
+        selstar b (List.map (fun btb => 
+          List.map (fun bt => (tttable d (fst bt), snd bt)) btb) btbl)
+        (ttcond d c)
     | qunion b Q1 Q2 => qunion b (ttquery d Q1) (ttquery d Q2)
     | qinters b Q1 Q2 => qinters b (ttquery d Q1) (ttquery d Q2)
     | qexcept b Q1 Q2 => qexcept b (ttquery d Q1) (ttquery d Q2)
@@ -81,13 +87,13 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
   .
 
   Lemma j_select_inv :
-    forall d g b btm btb c s, forall P : (forall g0 q0 s0, j_query d g0 q0 s0 -> Prop),
-    (forall g1 H, forall Hbtb : j_btb d g btb g1, forall Hc : j_cond d (g1 ++ g) c,
+    forall d g b btm btbl c s, forall P : (forall g0 q0 s0, j_query d g0 q0 s0 -> Prop),
+    (forall g1 H, forall Hbtbl : j_btbl d g btbl g1, forall Hc : j_cond d (g1 ++ g) c,
      forall Html : j_tml (g1 ++ g) (List.map fst btm), forall Hs : s = List.map snd btm,
-       H = j_select _ _ _ _ _ _ _ _ Hbtb Hc Html Hs -> P g (select b btm btb c) s H) ->
-    forall H : j_query d g (select b btm btb c) s,
-    P g (select b btm btb c) s H.
-  intros d g b btm btb c s P Hinv H. dependent inversion H.
+       H = j_select _ _ _ _ _ _ _ _ Hbtbl Hc Html Hs -> P g (select b btm btbl c) s H) ->
+    forall H : j_query d g (select b btm btbl c) s,
+    P g (select b btm btbl c) s H.
+  intros d g b btm btbl c s P Hinv H. dependent inversion H.
   eapply Hinv. trivial.
   Qed.
 
@@ -97,9 +103,10 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
           (fun G0 Q0 s0 H0 => j_db d)
           (fun G0 T0 s0 H0 => j_db d)
           (fun G0 c0 H0 => j_db d)
+          (fun G0 btbl G1 H0 => j_db d) 
           (fun G0 btb G1 H0 => j_db d) 
           (fun G0 Q0 H0 => j_db d)
-          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ HWF).
+          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ HWF).
   Unshelve. all: simpl; intros; auto.
   Qed.
 
@@ -269,14 +276,14 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
   Qed.
 
   Lemma sem2_pred_true_aux' (d : D) (g : Ctx) tml Stml x h:
-    Ev.j_tml_sem g tml Stml ->
+    SQLSem2.j_tml_sem g tml Stml ->
     monadic_map (fun val => val) (to_list (Stml h)) = Some x ->
     forall Sc, SQLSem2.j_cond_sem d g (List.fold_right (fun (t : pretm) (acc : precond) => 
       (t IS NOT NULL) AND acc) (TRUE) tml) Sc ->
     Sc h = true.
   Proof.
     intros Html Hmap.
-    enough (forall t0 St0, List.In t0 tml -> Ev.j_tm_sem g t0 St0 -> exists v, St0 h = Some v).
+    enough (forall t0 St0, List.In t0 tml -> SQLSem2.j_tm_sem g t0 St0 -> exists v, St0 h = Some v).
     + generalize H. clear H Hmap Html. elim tml; simpl; intros.
       - inversion H0. apply (existT_eq_elim H2). intros. rewrite <- H4. reflexivity.
       - inversion H1. apply (existT_eq_elim H5). intros. rewrite <- H9. clear H5 H8 H9.
@@ -290,23 +297,23 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
         * generalize dependent Hmap. apply bind_elim. Focus 2. intros. discriminate Hmap.
           intros cl Hmap. apply bind_elim. Focus 2. intros. discriminate Hmap0.
           intros c Hc Hinj. unfold ret in Hinj. injection Hinj. clear Hinj. intro Hinj. exists c.
-          rewrite <- Hc. rewrite H0 in H. rewrite (Ev.j_tm_sem_fun _ _ _ H _ H1). reflexivity.
+          rewrite <- Hc. rewrite H0 in H. rewrite (SQLSem2.j_tm_sem_fun _ _ _ H _ H1). reflexivity.
         * generalize dependent Hmap. apply bind_elim. Focus 2. intros. discriminate Hmap. 
           intros cl Hmap. intros. apply (IHHtml _ Hmap _ _ H0 H1).
   Qed.
 
   Lemma sem2_pred_false_aux' (d : D) (g : Ctx) tml Stml h :
-    Ev.j_tml_sem g tml Stml ->
+    SQLSem2.j_tml_sem g tml Stml ->
     monadic_map (fun val => val) (to_list (Stml h)) = @None (list BaseConst) ->
     forall Sc, SQLSem2.j_cond_sem d g (List.fold_right (fun (t : pretm) (acc : precond) => 
       (t IS NOT NULL) AND acc) (TRUE) tml) Sc ->
     Sc h = false.
   Proof.
     intros Html Hmap.
-    cut (forall h t0 tml0 St0, Ev.j_tm_sem g t0 St0 -> St0 h = None -> List.In t0 tml0 -> 
+    cut (forall h t0 tml0 St0, SQLSem2.j_tm_sem g t0 St0 -> St0 h = None -> List.In t0 tml0 -> 
       forall Sc0, SQLSem2.j_cond_sem d g (List.fold_right (fun t1 acc => 
       (t1 IS NOT NULL) AND acc) (TRUE) tml0) Sc0 -> Sc0 h = false).
-    + intro Hcut. cut (exists t, List.In t tml /\ exists St, Ev.j_tm_sem g t St /\ St h = None).
+    + intro Hcut. cut (exists t, List.In t tml /\ exists St, SQLSem2.j_tm_sem g t St /\ St h = None).
       - intros H Sc Hc. decompose record H. apply (Hcut _ _ _ _ H2 H3 H1 Sc Hc).
       - generalize dependent Hmap. generalize dependent Stml. clear Hcut. elim tml.
         * intros Stml Html Hfalse. inversion Html. apply (existT_eq_elim H0); intros. rewrite <- H1 in Hfalse.
@@ -322,12 +329,13 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       - simpl. intros t1 tml1 IH t0 St0 Ht0 Hnone Hin Sc0 Hc0. inversion Hc0.
         apply (existT_eq_elim H2); intros. rewrite <- H6. destruct Hin.
         * subst. inversion H3. apply (existT_eq_elim H7); intros. rewrite <- H9.
-          rewrite (Ev.j_tm_sem_fun _ _ _ H1 _ Ht0). rewrite Hnone. reflexivity.
+          rewrite (SQLSem2.j_tm_sem_fun _ _ _ H1 _ Ht0). rewrite Hnone. reflexivity.
         * rewrite (IH _ _ Ht0 Hnone H7 _ H4). apply Bool.andb_false_intro2. reflexivity.
   Qed.
 
+(* XXX: Why SQLSem2.j_tml_sem and not 3VL? *)
   Lemma sem_bpred_tech : forall d G tml Stml h n p e,
-    Ev.j_tml_sem G tml Stml ->
+    SQLSem2.j_tml_sem G tml Stml ->
     forall Sc, SQLSem2.j_cond_sem d G (List.fold_right (fun t acc => cndand (cndnull false t) acc) cndtrue tml) Sc
       -> S3.is_btrue (negtb (S3.sem_bpred n p (to_list (Stml h)) e)) 
          = S2.is_btrue (S2.band (S2.bneg (S2.sem_bpred n p (to_list (Stml h)) e)) (Sc h)).
@@ -353,7 +361,8 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       apply (sem3_pred_unknown' _ _ _ _ e0).
   Qed.
 
-  Lemma fold_v_tml_sem1' g m tml Stml (Html : Ev.j_tml_sem g tml Stml) h Vl :
+(* XXX: same as above *)
+  Lemma fold_v_tml_sem1' g m tml Stml (Html : SQLSem2.j_tml_sem g tml Stml) h Vl :
           Vl ~= Stml h ->
            (fun rl => fold_right2 (fun r0 V0 acc => 
               acc && S2.is_btrue (S2.veq r0 V0))%bool true m rl Vl)
@@ -387,7 +396,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
   Qed.
 
   Lemma cond_sem_cndeq_true1' d G t1 t2 St1 St2 h k :
-    Ev.j_tm_sem G t1 St1 -> Ev.j_tm_sem G t2 St2 ->
+    SQLSem2.j_tm_sem G t1 St1 -> SQLSem2.j_tm_sem G t2 St2 ->
     St1 h = Some k -> St2 h = Some k ->
     exists Sc, SQLSem2.j_cond_sem d G (cndeq t1 t2) Sc /\ Sc h = true.
   Proof.
@@ -411,16 +420,16 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
 
   Lemma cond_sem_cndeq_true2' d G t1 t2 Sc St1 St2 h :
     SQLSem2.j_cond_sem d G (cndeq t1 t2) Sc -> Sc h = true -> 
-    Ev.j_tm_sem G t1 St1 -> Ev.j_tm_sem G t2 St2 ->
+    SQLSem2.j_tm_sem G t1 St1 -> SQLSem2.j_tm_sem G t2 St2 ->
     exists k, St1 h = Some k /\ St2 h = Some k.
   Proof.
     intros Hc eSc Ht1 Ht2. inversion Hc. 
     apply (existT_eq_elim H2); intros; subst; clear H2.
     apply (existT_eq_elim H4); intros; subst; clear H4.
     clear H H5.
-    eapply (Ev.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => _) _ H1). Unshelve. intros.
+    eapply (SQLSem2.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => _) _ H1). Unshelve. intros.
     apply (existT_eq_elim H5); intros; subst; clear H5 H6.
-    eapply (Ev.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => _) _ H4). Unshelve. intros.
+    eapply (SQLSem2.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => _) _ H4). Unshelve. intros.
     apply (existT_eq_elim H8); intros; subst; clear H8 H9.
     inversion H5. apply (existT_eq_elim H7); intros; subst; clear H7 H6.
     generalize dependent eSc. apply S2.sem_bpred_elim.
@@ -434,11 +443,12 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
           -- symmetry. apply Db.BaseConst_eqb_eq. exact Heq.
         * intros cl Hfalse. discriminate Hfalse.
       - destruct (St2 h); intros cl Hfalse; discriminate Hfalse.
-      - apply (Ev.j_tm_sem_fun _ _ _ Ht2 _ H3).
-      - apply (Ev.j_tm_sem_fun _ _ _ Ht1 _ H2).
+      - apply (SQLSem2.j_tm_sem_fun _ _ _ Ht2 _ H3).
+      - apply (SQLSem2.j_tm_sem_fun _ _ _ Ht1 _ H2).
     + intros _ Hfalse. discriminate Hfalse.
   Qed.
 
+  (* XXX: SQLSem2/3? *)
   Lemma cond_sem_not_neq_iff' d g s tml (Hlen : length s = length tml) : 
     forall Stml Sc (ul : Rel.T (length tml)), 
     forall h h' h'', h = Ev.env_app (s::List.nil) _ h'' h' -> is_subenv' ul (Hlen : length s = 0 + length tml) h ->
@@ -447,7 +457,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
         (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc) 
         (TRUE) (combine tml s))
       Sc ->
-    Ev.j_tml_sem g tml Stml -> 
+    SQLSem2.j_tml_sem g tml Stml -> 
     (Sc h = true <-> forall i, S3.is_bfalse (S3.veq (nth ul i) (nth (Stml h') i)) = false).
   Proof.
     eapply (@list_rect2 _ _ (fun s0 tml0 =>
@@ -459,7 +469,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       SQLSem2.j_cond_sem d (s :: g)
         (List.fold_right (fun (ta : pretm * Name) acc =>
           let (t,a) := ta in (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc) (TRUE) (combine tml0 s0)) Sc -> 
-      Ev.j_tml_sem g tml0 Stml ->
+      SQLSem2.j_tml_sem g tml0 Stml ->
       Sc h  = true
       <-> (forall i, S3.is_bfalse (S3.veq (nth ul i) (nth (Stml h') i)) = false))
       _ _ _ _  Hlen List.nil eq_refl Hlen). Unshelve.
@@ -468,18 +478,18 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       - generalize h. inversion H2. intros. apply (existT_eq_elim H6). intros; subst. reflexivity.
     + simpl. intros x t s0 tml0 Hlen0 IH s1 Hs Hlens Stml0 Sc ul h h' h'' Happ Hsub Hc Html. split; intro.
       - intro i.
-        cut (forall St, Ev.j_tm_sem g t St -> nth ul Fin.F1 = null \/ St h' = Db.null \/ St h' = nth ul Fin.F1).
+        cut (forall St, SQLSem2.j_tm_sem g t St -> nth ul Fin.F1 = null \/ St h' = Db.null \/ St h' = nth ul Fin.F1).
         * generalize dependent Hsub.
           cut (forall i0 (ul1 : Rel.T (S (length tml0))), i0 ~= i -> ul1 ~= ul -> 
             is_subenv' ul1 Hlens h ->
-            (forall St, Ev.j_tm_sem g t St -> nth ul1 Fin.F1 = null \/ St h' = null \/ St h' = nth ul1 Fin.F1) ->
+            (forall St, SQLSem2.j_tm_sem g t St -> nth ul1 Fin.F1 = null \/ St h' = null \/ St h' = nth ul1 Fin.F1) ->
             S3.is_bfalse (S3.veq (nth ul i0) (nth (Stml0 h') i)) = false). intro Hcut. apply Hcut. reflexivity. reflexivity.
           dependent inversion ul with (fun m (ul0 : Rel.T m) => forall i0 (ul1 : Rel.T (S (length tml0))),
             i0 ~= i -> ul1 ~= ul0 -> is_subenv' ul1 Hlens h ->
-            (forall St, Ev.j_tm_sem g t St -> nth ul1 Fin.F1 = null \/ St h' = null \/ St h' = nth ul1 Fin.F1) ->
+            (forall St, SQLSem2.j_tm_sem g t St -> nth ul1 Fin.F1 = null \/ St h' = null \/ St h' = nth ul1 Fin.F1) ->
             S3.is_bfalse (S3.veq (nth ul0 i0) (nth (Stml0 h') i)) = false).
           intros i0 ul1 Hi0 Hul1; rewrite Hi0, Hul1; clear Hi0. intro Hsub.
-          cut (exists St Stml1, Ev.j_tm_sem g t St /\ Ev.j_tml_sem g tml0 Stml1).
+          cut (exists St Stml1, SQLSem2.j_tm_sem g t St /\ SQLSem2.j_tml_sem g tml0 Stml1).
           ++ intro. decompose record H0. clear H0.
              replace (Stml0 h') with (Vector.cons _ (x0 h') _ (x1 h')).
              intro Hcut. simpl in Hcut.
@@ -513,14 +523,14 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                   --- eapply cons_is_subenv'. exact Hsub.
                 +++ do 2 rewrite app_length. simpl. rewrite Hlen0. omega.
             -- apply JMeq_eq. assert (forall h1, h1 ~= h' -> cons _ (x0 h') _ (x1 h') ~= Stml0 h1).
-                eapply (Ev.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => forall h1, h1 ~= h' ->
+                eapply (SQLSem2.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => forall h1, h1 ~= h' ->
                         cons _ (x0 h') _ (x1 h') ~= S' h1) _ Html). Unshelve. Focus 2.
                simpl. intros. apply (existT_eq_elim H8); intros; subst; clear H8. apply eq_JMeq.
-               f_equal. rewrite (Ev.j_tm_sem_fun _ _ _ H2 _ H3). reflexivity.
-               rewrite (Ev.j_tml_sem_fun _ _ _ H4 _ H5). reflexivity.
+               f_equal. rewrite (SQLSem2.j_tm_sem_fun _ _ _ H2 _ H3). reflexivity.
+               rewrite (SQLSem2.j_tml_sem_fun _ _ _ H4 _ H5). reflexivity.
                apply H0. reflexivity.
-          ++ eapply (Ev.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => 
-                exists St Stml1, Ev.j_tm_sem g t St /\ Ev.j_tml_sem g tml0 Stml1) _ Html). Unshelve.
+          ++ eapply (SQLSem2.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => 
+                exists St Stml1, SQLSem2.j_tm_sem g t St /\ SQLSem2.j_tml_sem g tml0 Stml1) _ Html). Unshelve.
              simpl. intros. apply (existT_eq_elim H6); intros; subst; clear H6. exists St. exists Stml1.
              split. exact H2. exact H4.
         * generalize Hc, H. cut (forall h0, h0 ~= h -> SQLSem2.j_cond_sem d (s :: g)
@@ -528,7 +538,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
               AND List.fold_right (fun (ta : pretm * Name) (acc : precond) => let (t0, a) := ta in
               ((tmvar (0, a) IS NULL) OR ((tm_lift t0 1 IS NULL) OR cndeq (tm_lift t0 1) (tmvar (0, a)))) AND acc)
              (TRUE) (combine tml0 s0)) Sc -> Sc h0 = true ->
-            forall St, Ev.j_tm_sem g t St -> nth ul Fin.F1 = null \/ St h' = null \/ St h' = nth ul Fin.F1).
+            forall St, SQLSem2.j_tm_sem g t St -> nth ul Fin.F1 = null \/ St h' = null \/ St h' = nth ul Fin.F1).
             intro Hcut1; apply Hcut1; reflexivity.
           inversion Hc. intros h1 Hh1; rewrite Hh1; clear h1 Hh1.
           apply (existT_eq_elim H3); intros; subst.
@@ -545,7 +555,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
              inversion H11. apply (existT_eq_elim H19); intros; subst; clear H19.
              destruct (St0 (Ev.env_app _ _ h'' h')) eqn:Hsem. discriminate H0. 
              inversion H17. inversion H19. apply (existT_eq_elim H22); intros; subst; clear H22.
-             assert (Hsuba : j_var x (s1 ++ x :: s0)). apply (Ev.j_var_sem_j_var _ _ _ H25).
+             assert (Hsuba : j_var x (s1 ++ x :: s0)). apply (SQLSem2.j_var_sem_j_var _ _ _ H25).
              assert (Hsubk : 0 < S (length tml0)). omega.
              assert (Hfind : proj1_sig (Fin.to_nat (Fin_findpos x (s1 ++ x :: s0) Hsuba)) = 0 + length s1).
              rewrite (Fin_findpos_tech _ _ _ _ _ eq_refl). reflexivity.
@@ -555,8 +565,8 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
              reflexivity.
           ++ intro. eapply (S2_is_btrue_or_elim _ _ _ _ _ H0). Unshelve.
             -- intro. inversion H14. apply (existT_eq_elim H20); intros; subst; clear H20.
-               pose (H10' := Ev.j_tm_sem_weak _ ((s1++x::s0)::List.nil) _ _ H10); clearbody H10'.
-               rewrite (Ev.j_tm_sem_fun _ _ _ H18 _ H10') in H1. 
+               pose (H10' := SQLSem2.j_tm_sem_weak _ ((s1++x::s0)::List.nil) _ _ H10); clearbody H10'.
+               rewrite (SQLSem2.j_tm_sem_fun _ _ _ H18 _ H10') in H1. 
                replace (St (Ev.subenv2 (Ev.env_app ((s1 ++ x :: s0) :: Datatypes.nil) g h'' h'))) with (St h') in H1.
                destruct (St h'); try discriminate H1. right. left. reflexivity.
                f_equal. apply Ev.env_eq. unfold Ev.subenv2, Ev.env_app. simpl.
@@ -568,7 +578,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                enough (exists k, St0 (Ev.env_app _ _ h'' h') = Some k /\ St1 (Ev.env_app _ _ h'' h') = Some k).
                decompose record H2.
                inversion H19. inversion H26. apply (existT_eq_elim H28); intros; subst; clear H28.
-               assert (Hsuba : j_var x (s1 ++ x :: s0)). apply (Ev.j_var_sem_j_var _ _ _ H31). 
+               assert (Hsuba : j_var x (s1 ++ x :: s0)). apply (SQLSem2.j_var_sem_j_var _ _ _ H31). 
                assert (Hsubk : 0 < S (length tml0)). omega.
                assert (Hfind : proj1_sig (Fin.to_nat (Fin_findpos x (s1 ++ x :: s0) Hsuba)) = 0 + length s1).
                rewrite (Fin_findpos_tech _ _ _ _ _ eq_refl). reflexivity.
@@ -576,8 +586,8 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                replace (nth ul Fin.F1) with (nth ul (Fin.of_nat_lt Hsubk)). rewrite <- H24.
                rewrite (Ev.j_var_sem_fun _ _ _ H17 _ H31).
                unfold Scm in H22. rewrite H22. rewrite <- H20.
-               pose (H10' := Ev.j_tm_sem_weak _ ((s1++x::s0)::List.nil) _ _ H10); clearbody H10'.
-               rewrite (Ev.j_tm_sem_fun _ _ _ H18 _ H10'). f_equal. apply Ev.env_eq. 
+               pose (H10' := SQLSem2.j_tm_sem_weak _ ((s1++x::s0)::List.nil) _ _ H10); clearbody H10'.
+               rewrite (SQLSem2.j_tm_sem_fun _ _ _ H18 _ H10'). f_equal. apply Ev.env_eq. 
                unfold Ev.subenv2, Ev.env_app. simpl.
                transitivity (skipn (length (projT1 h'')) (projT1 h'' ++ projT1 h')).
                rewrite Ev.skipn_append. reflexivity. f_equal. rewrite Ev.length_env. reflexivity.
@@ -600,10 +610,10 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                  rewrite <- H15.
                  erewrite (SQLSem2.jc_sem_fun_dep _ _ _ _ H11 _ _ _ _ _ H13). reflexivity.
                  Unshelve. reflexivity. reflexivity.
-            -- cut (exists St0', Ev.j_tm_sem g t St0').
+            -- cut (exists St0', SQLSem2.j_tm_sem g t St0').
                ** intro Ht0'. destruct Ht0'. replace (St0 (Ev.env_app _ _ h'' h')) with (x0 h').
                   inversion H2. inversion H17. apply (existT_eq_elim H19); intros; subst; clear H19.
-                  assert (Hsuba : j_var x (s1 ++ x :: s0)). apply (Ev.j_var_sem_j_var _ _ _ H22).
+                  assert (Hsuba : j_var x (s1 ++ x :: s0)). apply (SQLSem2.j_var_sem_j_var _ _ _ H22).
                   assert (Hsubk : 0 < S (length tml0)). omega.
                   assert (Hfind : proj1_sig (Fin.to_nat (Fin_findpos x (s1 ++ x :: s0) Hsuba)) = 0 + length s1).
                   rewrite (Fin_findpos_tech _ _ _ _ _ eq_refl). reflexivity.
@@ -613,22 +623,22 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                   destruct (not_veq_false _ _ H').
                   +++ rewrite H15 in H13. rewrite (Ev.j_var_sem_fun _ _ _ H1 _ H22) in H13. unfold Scm in eSt. rewrite H13 in eSt. discriminate eSt.
                   +++ assert (forall h0 (f0 : Fin.t (length (t::tml0))), h0 ~= h' -> f0 ~= (Fin.F1 : Fin.t (length (t::tml0)))-> nth (Stml0 h0) f0 = x0 h').
-                      eapply (Ev.j_tml_cons_sem _ _ _ _ (fun _ t' tml' S' =>
+                      eapply (SQLSem2.j_tml_cons_sem _ _ _ _ (fun _ t' tml' S' =>
                         forall h0 (f0 : Fin.t (length (t'::tml'))), h0 ~= h' -> f0 ~= (Fin.F1 : Fin.t (length (t::tml0))) -> nth (S' h0) f0 = x0 h') _ Html).
                       Unshelve. Focus 2. intros. apply (existT_eq_elim H25); intros; subst; clear H25. simpl.
-                      rewrite (Ev.j_tm_sem_fun _ _ _ H0 _ H19). reflexivity.
+                      rewrite (SQLSem2.j_tm_sem_fun _ _ _ H0 _ H19). reflexivity.
                       pose (H18' := (H18 h' Fin.F1 JMeq_refl JMeq_refl) : @nth Rel.V (S (@length pretm tml0)) (Stml0 h') (@Fin.F1 (@length pretm tml0)) = x0 h'); clearbody H18'.
                       rewrite H18' in H15. destruct H15. left. exact H15.
                       right. rewrite <- H15. rewrite <- H13.
                       rewrite (Ev.j_var_sem_fun _ _ _ H1 _ H22). reflexivity.
                   +++ reflexivity.
-                  +++ pose (H0' := Ev.j_tm_sem_weak _ ((s1++x::s0)::List.nil) _ _ H0); clearbody H0'.
-                      rewrite (Ev.j_tm_sem_fun _ _ _ H3 _ H0'). f_equal.
+                  +++ pose (H0' := SQLSem2.j_tm_sem_weak _ ((s1++x::s0)::List.nil) _ _ H0); clearbody H0'.
+                      rewrite (SQLSem2.j_tm_sem_fun _ _ _ H3 _ H0'). f_equal.
                       apply Ev.env_eq. unfold Ev.subenv2, Ev.env_app. simpl.
                       transitivity (skipn (length (projT1 h'')) (projT1 h'' ++ projT1 h')).
                       rewrite Ev.skipn_append. reflexivity. f_equal. rewrite Ev.length_env. reflexivity.
-               ** eapply (Ev.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => 
-                    exists St0', Ev.j_tm_sem g t St0') _ Html). Unshelve.
+               ** eapply (SQLSem2.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => 
+                    exists St0', SQLSem2.j_tm_sem g t St0') _ Html). Unshelve.
                   simpl. intros. apply (existT_eq_elim H18); intros; subst; clear H18.
                   exists St1. exact H1.
          ++ discriminate eSc0.
@@ -649,8 +659,8 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
             -- rewrite <- app_assoc. reflexivity.
             -- generalize Hsub. rewrite Hul. apply cons_is_subenv'.
             -- exact H5.
-            -- eapply (Ev.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' =>
-                        Ev.j_tml_sem g' tml' (fun h0 => tl (S' h0))) _ Html). Unshelve.
+            -- eapply (SQLSem2.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' =>
+                        SQLSem2.j_tml_sem g' tml' (fun h0 => tl (S' h0))) _ Html). Unshelve.
                intros. simpl. apply (existT_eq_elim H15); intros; subst; clear H15.
                replace Stml1 with (fun h0 => tl (cons _ (St h0) _ (Stml1 h0))) in H3. exact H3.
                extensionality h0. reflexivity.
@@ -666,10 +676,11 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     unfold is_subenv'. intros. destruct (Hsub a Ha k0 Hk H0). eexists. exact H1.
   Qed.
 
+  (* XXX: SQLSem2/3 *)
   Lemma tech_sem_cndeq d g t1 t2 Sc St1 St2 : 
     SQLSem2.j_cond_sem d g (cndeq t1 t2) Sc ->
-    Ev.j_tm_sem g t1 St1 ->
-    Ev.j_tm_sem g t2 St2 ->
+    SQLSem2.j_tm_sem g t1 St1 ->
+    SQLSem2.j_tm_sem g t2 St2 ->
     forall h, Sc h = S2.veq (St1 h) (St2 h).
   Proof.
     unfold cndeq. intros. inversion H. 
@@ -679,7 +690,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     apply (existT_eq_elim H6). intros; subst; clear H6 H8.
     inversion H7.
     apply (existT_eq_elim H8). intros; subst; clear H8 H10.
-    rewrite (Ev.j_tm_sem_fun _ _ _ H5 _ H0). rewrite (Ev.j_tm_sem_fun _ _ _ H6 _ H1).
+    rewrite (SQLSem2.j_tm_sem_fun _ _ _ H5 _ H0). rewrite (SQLSem2.j_tm_sem_fun _ _ _ H6 _ H1).
     inversion H9. apply (existT_eq_elim H3). intros; subst; clear H2 H3.
     apply S2.sem_bpred_elim.
     + simpl. intro. apply bind_elim.
@@ -701,9 +712,10 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
         * intro. rewrite H2. unfold S2.veq. destruct (St1 h); intuition.
   Qed.
 
+  (* XXX: SQLSem2/3 *)
   Lemma tech_term_eq d g t a s1 al Sa St Sc h h0 x :
-    Ev.j_tm_sem g t St ->
-    Ev.j_tm_sem (((s1 ++ a:: List.nil) ++ al)::g) (tmvar (0,a)) Sa -> Sa (Ev.env_app (((s1 ++ a :: Datatypes.nil) ++ al) :: Datatypes.nil) g h0 h) = x ->
+    SQLSem2.j_tm_sem g t St ->
+    SQLSem2.j_tm_sem (((s1 ++ a:: List.nil) ++ al)::g) (tmvar (0,a)) Sa -> Sa (Ev.env_app (((s1 ++ a :: Datatypes.nil) ++ al) :: Datatypes.nil) g h0 h) = x ->
     SQLSem2.j_cond_sem d (((s1 ++ a :: Datatypes.nil) ++ al) :: g)
        ((tmvar (0, a) IS NULL) OR ((tm_lift t 1 IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a)))) Sc ->
     Sc (Ev.env_app (((s1 ++ a :: List.nil) ++ al) :: List.nil) _ h0 h) = negb (S3.is_bfalse (S3.veq x (St h))).
@@ -717,9 +729,9 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       inversion H5. apply (existT_eq_elim H4); intros; subst; clear H4 H5 H7.
       inversion H6. apply (existT_eq_elim H4); intros; subst; clear H4 H6 H8.
       inversion H5. apply (existT_eq_elim H6); intros; subst; clear H5 H6 H8.
-      assert (Ev.j_tm_sem ((((s1 ++ a :: List.nil) ++ al) :: List.nil) ++ g) (tm_lift t 1) (fun h => St (Ev.subenv2 h))).
-        apply Ev.j_tm_sem_weak. exact H.
-      rewrite (Ev.j_tm_sem_fun _ _ _ H3 _ H0).
+      assert (SQLSem2.j_tm_sem ((((s1 ++ a :: List.nil) ++ al) :: List.nil) ++ g) (tm_lift t 1) (fun h => St (Ev.subenv2 h))).
+        apply SQLSem2.j_tm_sem_weak. exact H.
+      rewrite (SQLSem2.j_tm_sem_fun _ _ _ H3 _ H0).
       replace (Ev.subenv2 (Ev.env_app (((s1 ++ a :: Datatypes.nil) ++ al) :: Datatypes.nil) g h0 h)) with h.
         Focus 2. apply Ev.env_eq. unfold Ev.subenv2, Ev.env_app. simpl.
         transitivity (skipn (length (projT1 h0)) (projT1 h0 ++ projT1 h)).
@@ -727,7 +739,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
         f_equal. rewrite Ev.length_env. reflexivity.
       destruct H9.
       - replace (St0 (Ev.env_app _ _ h0 h)) with null. reflexivity.
-        rewrite (Ev.j_tm_sem_fun _ _ _ H2 _ Ha). rewrite H1. reflexivity.
+        rewrite (SQLSem2.j_tm_sem_fun _ _ _ H2 _ Ha). rewrite H1. reflexivity.
       - destruct H1.
         * unfold S2.bor. apply Bool.orb_true_intro. right. rewrite H1. reflexivity.
         * decompose record H1. rewrite H5. replace (St0 (Ev.env_app _ _ h0 h)) with (Some x0). simpl.
@@ -740,15 +752,15 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
           transitivity (skipn (length (projT1 h0)) (projT1 h0 ++ projT1 h)).
           rewrite Ev.length_env. reflexivity.
           rewrite Ev.skipn_append. reflexivity.
-          rewrite (Ev.j_tm_sem_fun _ _ _ H2 _ Ha). rewrite H4.
+          rewrite (SQLSem2.j_tm_sem_fun _ _ _ H2 _ Ha). rewrite H4.
           f_equal. symmetry. apply Db.BaseConst_eqb_eq. exact H8.
     + inversion H0. apply (existT_eq_elim H4); intros; subst; clear H0 H4 H7.
       inversion H5. apply (existT_eq_elim H4); intros; subst; clear H4 H5 H7.
       inversion H6. apply (existT_eq_elim H4); intros; subst; clear H4 H6 H8.
       inversion H5. apply (existT_eq_elim H6); intros; subst; clear H5 H6 H8.
-      assert (Ev.j_tm_sem ((((s1 ++ a :: List.nil) ++ al) :: List.nil) ++ g) (tm_lift t 1) (fun h => St (Ev.subenv2 h))).
-        apply Ev.j_tm_sem_weak. exact H.
-      rewrite (Ev.j_tm_sem_fun _ _ _ H3 _ H0) in H9.
+      assert (SQLSem2.j_tm_sem ((((s1 ++ a :: List.nil) ++ al) :: List.nil) ++ g) (tm_lift t 1) (fun h => St (Ev.subenv2 h))).
+        apply SQLSem2.j_tm_sem_weak. exact H.
+      rewrite (SQLSem2.j_tm_sem_fun _ _ _ H3 _ H0) in H9.
       replace (Ev.subenv2 (Ev.env_app (((s1 ++ a :: Datatypes.nil) ++ al) :: Datatypes.nil) g h0 h)) with h in H9.
         Focus 2. apply Ev.env_eq. unfold Ev.subenv2, Ev.env_app. simpl.
         transitivity (skipn (length (projT1 h0)) (projT1 h0 ++ projT1 h)).
@@ -758,14 +770,14 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       - destruct (St0 (Ev.env_app _ _ h0 h)) eqn:eSt0.
         * intro Hfalse. discriminate Hfalse.
         * intros _. left. unfold null. rewrite <- eSt0.
-          rewrite (Ev.j_tm_sem_fun _ _ _ Ha _ H2). reflexivity.
+          rewrite (SQLSem2.j_tm_sem_fun _ _ _ Ha _ H2). reflexivity.
       - apply bool_orb_elim.
         * destruct (St h) eqn:eSt. intro Hfalse; discriminate Hfalse. intros _. right. left. reflexivity.
         * replace (Sc0 (Ev.env_app _ _ h0 h)) with (S2.veq (St h) (St0 (Ev.env_app _ _ h0 h))).
           unfold S2.veq. destruct (St h) eqn:eSt.
           ++ destruct (St0 (Ev.env_app _ _ h0 h)) eqn:eSt0.
             -- intro. right. right. exists b. exists b0. intuition.
-               rewrite (Ev.j_tm_sem_fun _ _ _ Ha _ H2). rewrite eSt0. 
+               rewrite (SQLSem2.j_tm_sem_fun _ _ _ Ha _ H2). rewrite eSt0. 
                symmetry. f_equal. apply Db.BaseConst_eqb_eq. exact H1.
                f_equal. apply Db.BaseConst_eqb_eq. exact H1.
             -- intro Hfalse. discriminate Hfalse.
@@ -826,9 +838,10 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       simpl. intuition.
   Qed.
 
+  (* XXX: SQLSem2/3 *)
   Lemma tech_vec_append_tmvar : forall a s1 s2 (x:Rel.T (S (length s2))) (y:Rel.T (length s1)) e g h,
     forall Sa,
-    Ev.j_tm_sem ((s1++a::s2)::g) (tmvar (0,a)) Sa ->
+    SQLSem2.j_tm_sem ((s1++a::s2)::g) (tmvar (0,a)) Sa ->
     Sa (Ev.env_app _ g (Ev.env_of_tuple ((s1++a::s2)::List.nil) (cast _ _ e (Vector.append y x))) h) = hd x.
   Proof.
     intros. inversion H. subst. inversion H3. apply (existT_eq_elim H1). intros; subst; clear H1 H6.
@@ -842,12 +855,13 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     + rewrite firstn_app_2. simpl. rewrite app_nil_r. reflexivity.
   Qed.
 
+  (* XXX: SQLSem2/3 *)
   Lemma tech_sem_not_exists' d g tml s ul1 (ul2 : Rel.T (length tml)) Sc Stml h :
     length s = length tml -> ul1 ~= ul2 ->
     SQLSem2.j_cond_sem d (s :: g)%list 
       (List.fold_right (fun (ta : pretm * Name) acc => let (t, a) := ta in (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc) (TRUE) (combine tml s)) 
       Sc ->
-    Ev.j_tml_sem g tml Stml ->
+    SQLSem2.j_tml_sem g tml Stml ->
     Sc (Ev.env_app _ _ (Ev.env_of_tuple (s :: List.nil) ul1) h)
     = fold_right2 (fun (u0 v0 : Value) (acc : bool) => (acc && negb (S3.is_bfalse (S3.veq u0 v0)))%bool)
         true (length tml) ul2 (Stml h).
@@ -856,7 +870,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     enough 
       (forall s1, 
          forall ul1 ul2 (ul0 : Rel.T (length s1)), ul1 ~= Vector.append ul0 ul2 -> 
-         forall Stml, Ev.j_tml_sem g tml Stml -> 
+         forall Stml, SQLSem2.j_tml_sem g tml Stml -> 
          forall Sc, SQLSem2.j_cond_sem d ((s1++s)::g) 
           (List.fold_right (fun (ta:pretm*Name) acc =>
               let (t, a) := ta in
@@ -868,7 +882,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     clear ul1 ul2 Sc Stml Heq Hc Html.
     eapply (list_ind2 _ _ (fun s0 tml0 =>
         forall s1 ul1 ul2 ul0, ul1 ~= append ul0 ul2 -> 
-        forall Stml, Ev.j_tml_sem g tml0 Stml -> 
+        forall Stml, SQLSem2.j_tml_sem g tml0 Stml -> 
         forall Sc, SQLSem2.j_cond_sem d ((s1++s0) :: g)
           (List.fold_right
              (fun (ta : pretm * Name) (acc : precond) =>
@@ -920,7 +934,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
         (acc && negb (S3.is_bfalse (S3.veq u0 v0)))%bool) true (length bl) ul2' (Stml0 h)).
       rewrite <- (H0 s1' ul1' ul2' ul0' Heq' _ H8 _ H9).
       apply f_equal. f_equal. apply JMeq_eq. symmetry. eapply (JMeq_trans _ H5). Unshelve.
-      reflexivity. assert (Ha : exists Sa, Ev.j_tm_sem (((s1 ++ a :: Datatypes.nil) ++ al) :: g) (tmvar (0,a)) Sa).
+      reflexivity. assert (Ha : exists Sa, SQLSem2.j_tm_sem (((s1 ++ a :: Datatypes.nil) ++ al) :: g) (tmvar (0,a)) Sa).
         inversion H7. apply (existT_eq_elim H13). intros; subst; clear H13 H16.
         inversion H14. apply (existT_eq_elim H16). intros; subst; clear H16 H17. exists St0. exact H12.
       destruct Ha as [Sa Ha]. eapply (tech_term_eq _ _ _ _ _ _ _ _ _ _ _ _ H6 Ha _ H7). Unshelve. Focus 11.
@@ -971,8 +985,65 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       rewrite <- app_assoc. reflexivity.
   Qed.
 
+  Lemma tech_j_var_sem : forall a s, List.In a s -> NoDup s -> 
+    exists Sa : Ev.env (s :: Datatypes.nil) -> Value, Ev.j_var_sem s a Sa.
+  Proof.
+    intros a s. elim s.
+    + intro H; destruct H.
+    + intros. inversion H1. destruct H0. 
+      - subst. eexists. constructor. exact H4.
+      - destruct (H H0 H5). subst. eexists. constructor. intro. contradiction H4. rewrite H2. exact H0.
+        exact H6.
+  Qed.
+
+  Lemma tech_j_cond_fold_vect' d s0 n (s : Vector.t Name n) g (tml : Vector.t pretm n) :
+    List.NoDup s0 -> forall Stml, SQLSem2.j_tml_sem g (to_list tml) Stml -> incl (to_list s) s0 ->
+    exists Sc : Ev.env ((s0 :: Datatypes.nil) ++ g) -> S2.B,
+    SQLSem2.j_cond_sem d ((s0 :: Datatypes.nil) ++ g)
+      (List.fold_right
+       (fun (ta : pretm * Name) (acc : precond) =>
+        let (t, a) := ta in
+        ((tmvar (0, a) IS NULL) OR ((tm_lift t 1 IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a)))) AND acc) 
+       (TRUE) (combine (VectorDef.to_list tml) (VectorDef.to_list s))) Sc.
+  Proof.
+    intros Hnodup.
+    eapply (Vector.rect2 (fun n s' tml' => 
+      forall Stml, SQLSem2.j_tml_sem g (to_list tml') Stml -> incl (to_list s') s0 -> 
+      exists Sc,
+      SQLSem2.j_cond_sem d ((s0 :: List.nil) ++ g) (List.fold_right
+        (fun (ta : pretm * Name) acc => let (t, a) := ta in (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc) (TRUE) 
+        (combine (to_list tml') (to_list s'))) Sc)
+      _ _ s tml). Unshelve.
+    + simpl. intros. eexists. constructor. 
+    + simpl. intros m s' tml' IH a0 t0 Stml Html' Hincl.
+      unfold to_list in Html'. 
+      eapply (SQLSem2.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => _) _ Html'). Unshelve. simpl. intros.
+      apply (existT_eq_elim H3); intros; subst; clear H3 H5.
+      enough (incl (to_list s') s0). destruct (IH _ H4 H0).
+      enough (exists Sa0, Ev.j_var_sem s0 a0 Sa0). destruct H3.
+      eexists. constructor. Focus 2. exact H1.
+      constructor. constructor. constructor. constructor. exact H3.
+      constructor. constructor. eapply (SQLSem2.j_tm_sem_weak g (s0::List.nil) _ _ H2).
+      constructor. constructor. eapply (SQLSem2.j_tm_sem_weak g (s0::List.nil) _ _ H2).
+      constructor. constructor. constructor. exact H3. constructor.
+      apply tech_j_var_sem. apply Hincl. left. reflexivity. exact Hnodup.
+      intros x Hx. apply Hincl. right. exact Hx.
+      Unshelve. reflexivity.
+  Qed.
+
+  Lemma tech_j_cond_fold' d s0 s g tml :
+    length tml = length s -> List.NoDup s0 -> forall Stml, SQLSem2.j_tml_sem g tml Stml-> incl s s0 ->
+    exists Sc,
+    SQLSem2.j_cond_sem d ((s0 :: Datatypes.nil) ++ g) (List.fold_right
+     (fun (ta : pretm * Name) (acc : precond) => let (t, a) := ta in (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc)
+     (TRUE) (combine tml s)) Sc.
+  Proof.
+    intro Hlen. rewrite <- (to_list_of_list_opp tml). rewrite <- (to_list_of_list_opp s).
+    generalize (of_list tml) (of_list s). rewrite Hlen. intros vtml vs. apply tech_j_cond_fold_vect'.
+  Qed.
+
   Lemma cond_sem_not_ex_selstar' d g q s s0 tml Hs0 (Hlens : length s = length s0) 
-     Sff Sq Sc (Hff : SQLSem2.j_cond_sem d g (NOT (EXISTS (SELECT * FROM (tbquery (ttquery d q), s0) :: Datatypes.nil
+     Sff Sq Sc (Hff : SQLSem2.j_cond_sem d g (NOT (EXISTS (SELECT * FROM ((tbquery (ttquery d q), s0) :: List.nil)::List.nil
       WHERE List.fold_right (fun (ta : pretm * Name) (acc : precond) =>
                 let (t, a) := ta in (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc) 
               (TRUE) (combine tml s0)))) Sff)
@@ -992,98 +1063,74 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     Focus 2. unfold S2.is_btrue, S2.bneg. intros. rewrite H. reflexivity.
     intro Hcut. apply Hcut. inversion H2. apply (existT_eq_elim H1); intros; subst. clear H2 H1 H4.
     inversion H3. apply (existT_eq_elim H5); intros; subst. clear H3 H5 H7.
-    inversion H2. apply (existT_eq_elim H8); intros; subst. clear H2 H8 H5 H11. 
-    apply (existT_eq_elim (JMeq_eq H12)); intros; subst. clear H12 H.
-    eapply (SQLSem2.j_nil_btb_sem _ _ _ _ _ _ H9). Unshelve. intros; subst. rewrite <- H2. clear H9 H2.
+    inversion H2. apply (existT_eq_elim H7); intros; subst. clear H2 H4 H7 H9.
+    apply (existT_eq_elim (JMeq_eq H10)); intros; subst. clear H10 H.
+    inversion H5. apply (existT_eq_elim H9); intros; subst. clear H5 H9 H4 H12.
+    apply (existT_eq_elim (JMeq_eq H13)); intros; subst. clear H13 H.
+    eapply (SQLSem2.j_nil_btb_sem _ _ _ _ _ _ H10). Unshelve. intros; subst. rewrite <- H2. clear H10 H2.
     inversion H7. apply (existT_eq_elim H2); intros; subst. clear H7 H2 H4.
     apply (existT_eq_elim (JMeq_eq H5)); intros; subst. clear H5 H.
+    eapply (SQLSem2.j_nil_btbl_sem _ _ _ _ _ _ H8). Unshelve.
+    intros; subst. rewrite <- H2.
     transitivity (0 <?
       Rel.card
         (Rel.sel
-           (cast (Rel.R (length s1 + list_sum (List.map (length (A:=Name)) Datatypes.nil)))
-              (Rel.R (length s0 + list_sum (List.map (length (A:=Name)) Datatypes.nil))) e
-              (Rel.times (ST h) Rel.Rone))
-           (fun Vl : Rel.T (list_sum (List.map (length (A:=Name)) (s0 :: Datatypes.nil))) =>
-            S2.is_btrue (Sc0 (Ev.env_app (s0 :: Datatypes.nil) g (Ev.env_of_tuple (s0 :: Datatypes.nil) Vl) h))))).
-    reflexivity. f_equal. apply eq_card_dep. rewrite Hlens. simpl. omega.
+           (Rel.rsum
+              (cast (Rel.R (length s1 + list_sum (List.map (length (A:=Name)) Datatypes.nil)))
+                 (Rel.R (length s0 + list_sum (List.map (length (A:=Name)) Datatypes.nil))) e0
+                 (Rel.times (ST h) Rel.Rone))
+              (fun Vl : Rel.T (list_sum (List.map (length (A:=Name)) (s0 :: Datatypes.nil))) =>
+               cast
+                 (Rel.R
+                    (list_sum (List.map (length (A:=Name)) Datatypes.nil) +
+                     list_sum (List.map (length (A:=Name)) (s0 :: Datatypes.nil))))
+                 (Rel.R (list_sum (List.map (length (A:=Name)) (Datatypes.nil ++ s0 :: Datatypes.nil)))) e
+                 (Rel.times Rel.Rone (Rel.Rsingle Vl))))
+           (fun Vl : Rel.T (list_sum (List.map (length (A:=Name)) (Datatypes.nil ++ s0 :: Datatypes.nil))) =>
+            S2.is_btrue
+              (Sc0
+                 (Evl.env_app (Datatypes.nil ++ s0 :: Datatypes.nil) g
+                    (Evl.env_of_tuple (Datatypes.nil ++ s0 :: Datatypes.nil) Vl) h))))).
+    reflexivity. f_equal.
+    apply eq_card_dep. rewrite Hlens. simpl. omega.
     eapply (f_JMequal (Rel.sel _) (Rel.sel _)).
     eapply (f_JMequal (@Rel.sel _) (@Rel.sel _)). rewrite Hlens. simpl. rewrite plus_0_r. reflexivity.
     destruct (SQLSem2.jq_sem_fun_dep _ _ _ _ _ Hq _ _ _ _ eq_refl eq_refl H3). subst.
-    apply cast_JMeq. symmetry. apply p_ext_dep. simpl. omega.
-    intros. replace r2 with (Vector.append r1 (Vector.nil _)).
-    rewrite (Rel.p_times _ _ _ _ _ r1 (nil _) eq_refl). rewrite Rel.p_one. rewrite H0. omega.
-    apply JMeq_eq. eapply (JMeq_trans (vector_append_nil_r r1)). exact H.
-    apply fun_ext_dep. rewrite Hlens. simpl. rewrite plus_0_r. reflexivity.
-    intros Vl1 Vl2 HVl. unfold S2.is_btrue. apply JMeq_eq. eapply (f_JMequal (eb:=JMeq_refl) Sc0 Sc).
-    eapply (SQLSem2.jc_sem_fun_dep _ _ _ _ H6 _ _ _ _ _ Hc).
-    eapply (f_JMequal (Ev.env_app _ _ _) (Ev.env_app _ _ _)).
-    eapply (f_JMequal (Ev.env_app _ _) (Ev.env_app _ _)). reflexivity.
-    eapply (f_JMequal (Ev.env_of_tuple _) (Ev.env_of_tuple _)). reflexivity.
-    symmetry. apply cast_JMeq. symmetry. exact HVl. reflexivity.
+    simpl. apply (@trans_JMeq _ _ _ _ (Rel.rsum (ST h) (fun Vl => Rel.Rsingle Vl))).
+      apply eq_rsum_dep. rewrite H11; omega. rewrite H11; omega. apply cast_JMeq. apply Rel_times_Rone.
+      apply funext_JMeq. rewrite H11, <- plus_n_O; reflexivity. rewrite H11, <- plus_n_O; reflexivity.
+      intros. apply cast_JMeq. apply (trans_JMeq (Rel_Rone_times _ (Rel.Rsingle x))).
+      generalize dependent x. rewrite <- (plus_n_O (length s0)), <- H11. intros. rewrite H. reflexivity.
+    eapply (trans_JMeq (rsum_id _ _ _ _ _)). rewrite H0. reflexivity.
+    apply funext_JMeq; intros.
+      simpl. rewrite <- plus_n_O, Hlens. reflexivity. reflexivity.
+    generalize (SQLSem2.jc_sem_fun_dep _ _ _ _ H6 _ _ _ eq_refl eq_refl Hc); intro.
+    rewrite H0. apply eq_JMeq. f_equal. f_equal.
+    f_equal. f_equal. symmetry. apply JMeq_eq. apply cast_JMeq. symmetry. exact H.
     Unshelve.
-    simpl. rewrite plus_0_r. rewrite Hlens. reflexivity.
-    simpl. rewrite plus_0_r. rewrite Hlens. reflexivity.
-    simpl. rewrite plus_0_r. rewrite Hlens. reflexivity.
-    simpl. rewrite plus_0_r. rewrite Hlens. reflexivity.
-    reflexivity. reflexivity. reflexivity. reflexivity. reflexivity. reflexivity. reflexivity.
-    reflexivity. reflexivity.
+    simpl. rewrite Hlens, <- plus_n_O. reflexivity.
+    simpl. rewrite Hlens, <- plus_n_O. reflexivity.
+    simpl. rewrite Hlens, <- plus_n_O. reflexivity.
+    simpl. rewrite Hlens, <- plus_n_O. reflexivity.
+    intro; reflexivity.
   Qed.
 
-  Lemma tech_j_var_sem : forall a s, List.In a s -> NoDup s -> 
-    exists Sa : Ev.env (s :: Datatypes.nil) -> Value, Ev.j_var_sem s a Sa.
+  Lemma sem_tm_bool_to_tribool {g} {t} {St} :
+    SQLSem3.j_tm_sem g t St -> SQLSem2.j_tm_sem g t St.
   Proof.
-    intros a s. elim s.
-    + intro H; destruct H.
-    + intros. inversion H1. destruct H0. 
-      - subst. eexists. constructor. exact H4.
-      - destruct (H H0 H5). subst. eexists. constructor. intro. contradiction H4. rewrite H2. exact H0.
-        exact H6.
+    intro; induction H; constructor; intuition.
   Qed.
 
-  Lemma tech_j_cond_fold_vect' d s0 n (s : Vector.t Name n) g (tml : Vector.t pretm n) :
-    List.NoDup s0 -> forall Stml, Ev.j_tml_sem g (to_list tml) Stml -> incl (to_list s) s0 ->
-    exists Sc : Ev.env ((s0 :: Datatypes.nil) ++ g) -> S2.B,
-    SQLSem2.j_cond_sem d ((s0 :: Datatypes.nil) ++ g)
-      (List.fold_right
-       (fun (ta : pretm * Name) (acc : precond) =>
-        let (t, a) := ta in
-        ((tmvar (0, a) IS NULL) OR ((tm_lift t 1 IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a)))) AND acc) 
-       (TRUE) (combine (VectorDef.to_list tml) (VectorDef.to_list s))) Sc.
+  Lemma sem_tml_bool_to_tribool {g} {tl} {Stl} :
+    SQLSem3.j_tml_sem g tl Stl -> SQLSem2.j_tml_sem g tl Stl.
   Proof.
-    intros Hnodup.
-    eapply (Vector.rect2 (fun n s' tml' => 
-      forall Stml, Ev.j_tml_sem g (to_list tml') Stml -> incl (to_list s') s0 -> 
-      exists Sc,
-      SQLSem2.j_cond_sem d ((s0 :: List.nil) ++ g) (List.fold_right
-        (fun (ta : pretm * Name) acc => let (t, a) := ta in (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc) (TRUE) 
-        (combine (to_list tml') (to_list s'))) Sc)
-      _ _ s tml). Unshelve.
-    + simpl. intros. eexists. constructor. 
-    + simpl. intros m s' tml' IH a0 t0 Stml Html' Hincl.
-      unfold to_list in Html'. 
-      eapply (Ev.j_tml_cons_sem _ _ _ _ (fun g' t' tml' S' => _) _ Html'). Unshelve. simpl. intros.
-      apply (existT_eq_elim H3); intros; subst; clear H3 H5.
-      enough (incl (to_list s') s0). destruct (IH _ H4 H0).
-      enough (exists Sa0, Ev.j_var_sem s0 a0 Sa0). destruct H3.
-      eexists. constructor. Focus 2. exact H1.
-      constructor. constructor. constructor. constructor. exact H3.
-      constructor. constructor. eapply (Ev.j_tm_sem_weak g (s0::List.nil) _ _ H2).
-      constructor. constructor. eapply (Ev.j_tm_sem_weak g (s0::List.nil) _ _ H2).
-      constructor. constructor. constructor. exact H3. constructor.
-      apply tech_j_var_sem. apply Hincl. left. reflexivity. exact Hnodup.
-      intros x Hx. apply Hincl. right. exact Hx.
-      Unshelve. reflexivity.
+    intro; induction H; constructor; intuition. apply sem_tm_bool_to_tribool. exact H.
   Qed.
 
-  Lemma tech_j_cond_fold' d s0 s g tml :
-    length tml = length s -> List.NoDup s0 -> forall Stml, Ev.j_tml_sem g tml Stml-> incl s s0 ->
-    exists Sc,
-    SQLSem2.j_cond_sem d ((s0 :: Datatypes.nil) ++ g) (List.fold_right
-     (fun (ta : pretm * Name) (acc : precond) => let (t, a) := ta in (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc)
-     (TRUE) (combine tml s)) Sc.
+  Lemma list_sum_app : forall l1 l2, list_sum (l1 ++ l2) = list_sum l1 + list_sum l2.
   Proof.
-    intro Hlen. rewrite <- (to_list_of_list_opp tml). rewrite <- (to_list_of_list_opp s).
-    generalize (of_list tml) (of_list s). rewrite Hlen. intros vtml vs. apply tech_j_cond_fold_vect'.
+    intros. induction l1; simpl; intuition.
+
   Qed.
 
   Theorem sem_bool_to_tribool : forall d G Q s SQ3,
@@ -1102,13 +1149,18 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
           (fun G0 G1 btb S0 _ => 
             exists S1, SQLSem2.j_btb_sem d G0 G1 (List.map (fun bT => (tttable d (fst bT), snd bT)) btb) S1 /\ 
             forall h, S0 h ~= S1 h)
+          (fun G0 G1 btbl S0 _ => 
+            exists S1, SQLSem2.j_btbl_sem d G0 G1 (List.map (fun btb => 
+              List.map (fun bT => (tttable d (fst bT), snd bT)) btb) btbl) S1 /\ 
+            forall h, S0 h ~= S1 h)
           (fun G0 Q0 S0 _ => exists S1, SQLSem2.j_in_q_sem d G0 (ttquery d Q0) S1 /\ forall h, S0 h ~= S1 h)
-          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H).
+          _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H).
   Unshelve.
   (** mutual induction cases: query *)
-  + simpl. intros G0 b tml btb c G1 Sbtb Sc Stml e Hbtb IHbtb Hc IHc Html.
-    decompose record IHbtb. decompose record IHc.
-    eexists. split. eapply (SQLSem2.jqs_sel _ _ _ _ _ _ _ _ _ _ e H1 H0 Html).
+  + simpl. intros G0 b tml btbl c G1 Sbtbl Sc Stml s0 e Hbtb IHbtbl Hc IHc Html.
+    decompose record IHbtbl. decompose record IHc.
+    eexists. split. eapply (SQLSem2.jqs_sel _ _ _ _ _ _ _ _ _ _ _ e H1 H0 (sem_tml_bool_to_tribool Html)).
+    exact e0.
     intro. simpl. destruct b.
     - apply eq_JMeq. f_equal. apply JMeq_eq. apply cast_JMeq. symmetry. apply cast_JMeq. rewrite H2.
       eapply (f_JMequal (Rel.sum _) (Rel.sum _)). Unshelve.
@@ -1120,9 +1172,10 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       eapply (f_JMeq _ _ (@Rel.sum _ _)). apply JMeq_eq. eapply (f_JMeq _ _ (Rel.sel _)).
       extensionality Vl. rewrite H4. reflexivity.
       reflexivity. reflexivity. reflexivity.
-  + simpl. intros G0 b btb c G1 Sbtb Sc Stml e Hbtb IHbtb Hc IHc Html.
+  + simpl. intros G0 b btb c s0 G1 Sbtb Sc Stml e Hbtb IHbtb Hc IHc Html.
     decompose record IHbtb. decompose record IHc.
-    eexists. split. eapply (SQLSem2.jqs_selstar _ _ _ _ _ _ _ _ _ e H1 H0 Html).
+    eexists. split. eapply (SQLSem2.jqs_selstar _ _ _ _ _ _ _ _ _ _ e H1 H0 (sem_tml_bool_to_tribool Html)).
+    exact e0.
     intro. simpl. destruct b.
     - apply eq_JMeq. f_equal. apply JMeq_eq. apply cast_JMeq. symmetry. apply cast_JMeq. rewrite H2.
       eapply (f_JMequal (Rel.sum _) (Rel.sum _)). Unshelve.
@@ -1160,14 +1213,16 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     split. constructor. split. constructor.
     split; intros; reflexivity. 
   + simpl. intros G0 b t St Ht. eexists. eexists. 
-    split. constructor. exact Ht. split. constructor. exact Ht.
+    split. constructor. exact (sem_tm_bool_to_tribool Ht). split. constructor. exact (sem_tm_bool_to_tribool Ht).
     split; intros; destruct (St h); destruct b; reflexivity. 
   + simpl. intros G0 n p tml Stml e Html.
     cut (exists Sc2, SQLSem2.j_cond_sem d G0 (List.fold_right (fun (t : pretm) (acc : precond) => 
       (t IS NOT NULL) AND acc) (TRUE) tml) Sc2).
     intro Hc2. decompose record Hc2. clear Hc2. eexists. eexists.
-    split. eapply (SQLSem2.jcs_pred _ _ _ _ _ _ e). Unshelve. exact Html.
-    split. constructor. Unshelve. constructor. Unshelve. constructor. Unshelve. exact Html.
+    split. eapply (SQLSem2.jcs_pred _ _ _ _ _ _ e). Unshelve. 
+    exact (sem_tml_bool_to_tribool Html).
+    split. constructor. Unshelve. constructor. Unshelve. constructor. Unshelve. 
+    exact (sem_tml_bool_to_tribool Html).
     exact H0. split.
     - intro. apply S3.sem_bpred_elim.
       * intros. apply S2.sem_bpred_elim; rewrite H1. 
@@ -1179,16 +1234,16 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
       * intros. apply S2.sem_bpred_elim; rewrite H1.
         intros. discriminate H2.
         intro. reflexivity.
-    - intro. erewrite <- (sem_bpred_tech _ _ _ _ _ _ _ _ Html). reflexivity. exact H0.
+    - intro. erewrite <- (sem_bpred_tech _ _ _ _ _ _ _ _ (sem_tml_bool_to_tribool Html)). reflexivity. exact H0.
     - elim Html.
       * simpl. eexists. constructor.
       * intros t0 tml0 St0 Stml0 Ht0 Html0 IH. destruct IH. simpl. eexists. constructor.
-        constructor. exact Ht0. exact H0. 
+        constructor. apply sem_tm_bool_to_tribool. exact Ht0. exact H0. 
   + hnf. intros G0 b tml q s0 Stml Sq e Html Hq IHq.
     decompose record IHq. destruct b.
     - cut (exists S2, SQLSem2.j_cond_sem d G0 (ffcond d (tml IN q)) S2).
       * intro Hff. decompose record Hff. clear Hff.
-        eexists. exists x0. split. constructor. exact Html. exact H1. split.
+        eexists. exists x0. split. constructor. apply sem_tml_bool_to_tribool. exact Html. exact H1. split.
         exact H0. split.
         ++ intro h. simpl.        
           destruct (0 <? Rel.card (Rel.sel (Sq h)
@@ -1197,7 +1252,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
             (length s0) rl (cast _ _ (f_equal Rel.T e) (Stml h))))) eqn:e0.
           -- transitivity true. reflexivity. symmetry. apply if_true.
             ** eapply (trans_eq _ e0). Unshelve. exact e. 
-               rewrite (fold_v_tml_sem1' _ _ _ _ Html h).
+               rewrite (fold_v_tml_sem1' _ _ _ _ (sem_tml_bool_to_tribool Html) h).
                rewrite H2. reflexivity. apply cast_JMeq. reflexivity.
             ** reflexivity.
           -- transitivity false.
@@ -1206,7 +1261,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                  (acc && negb (S3.is_bfalse (S3.veq r0 V0)))%bool) true (length s0) rl (cast _ _ (f_equal Rel.T e) (Stml h)))));
              reflexivity.
             ** symmetry. apply if_false.
-              +++ rewrite <- e0. rewrite (fold_v_tml_sem1' _ _ _ _ Html h).
+              +++ rewrite <- e0. rewrite (fold_v_tml_sem1' _ _ _ _ (sem_tml_bool_to_tribool Html) h).
                rewrite H2. reflexivity. apply cast_JMeq. reflexivity.
               +++ apply if_elim; reflexivity.
         ++ intro. rewrite H2. simpl in H0. pose (s1 := freshlist (length tml)).
@@ -1214,7 +1269,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                        (List.fold_right (fun (ta : pretm * Name) acc => let (t, a) := ta in (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc) 
                           (TRUE) (combine tml s1)) Sc).
            intro Hcut. Focus 2. eapply tech_j_cond_fold'.
-           symmetry. apply length_freshlist. apply p_freshlist. exact Html. intro. intuition.
+           symmetry. apply length_freshlist. apply p_freshlist. apply sem_tml_bool_to_tribool. exact Html. intro. intuition.
            decompose record Hcut. 
            assert (Rel.T (length s0) = Rel.T (list_sum (List.map (length (A:=Name)) (freshlist (length tml) :: Datatypes.nil)))).
              symmetry. rewrite <- length_concat_list_sum. simpl. rewrite app_length, length_freshlist.
@@ -1245,7 +1300,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                 rewrite e. reflexivity.
                 apply cast_JMeq. exact H5.
                 symmetry. apply cast_JMeq. reflexivity.
-                exact H3. exact Html. Unshelve.
+                exact H3. apply sem_tml_bool_to_tribool. exact Html. Unshelve.
                 rewrite e; reflexivity.
                 rewrite e; reflexivity.
                 rewrite e; reflexivity.
@@ -1271,26 +1326,27 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                     rewrite e. reflexivity.
                     symmetry. rewrite <- H5. exact H6.
                     symmetry. apply cast_JMeq. reflexivity.
-                    exact H3. exact Html. Unshelve.
+                    exact H3. apply sem_tml_bool_to_tribool. exact Html. Unshelve.
                     rewrite e; reflexivity.
                     rewrite e; reflexivity.
                     rewrite e; reflexivity.
                     rewrite e; reflexivity.
           -- symmetry. rewrite e. apply length_freshlist.
       * destruct (tech_j_cond_fold' d (freshlist (length tml)) (freshlist (length tml)) G0 _ 
-            (eq_sym (length_freshlist _)) (p_freshlist _) _ Html (fun x Hx => Hx)).
-        eexists. constructor. constructor. constructor. constructor. constructor. exact H1.
-        constructor. rewrite length_freshlist. symmetry. exact e. exact H0.
+            (eq_sym (length_freshlist _)) (p_freshlist _) _ (sem_tml_bool_to_tribool Html) (fun x Hx => Hx)).
+        eexists. constructor. constructor. constructor. constructor. constructor. constructor. exact H1.
+        constructor. rewrite length_freshlist. symmetry. exact e. constructor. exact H0.
         Unshelve. simpl. repeat rewrite plus_0_r. rewrite length_freshlist. rewrite e. reflexivity.
+        simpl. rewrite length_freshlist, e. reflexivity.
     - cut (exists S1, SQLSem2.j_cond_sem d G0 (ttcond d (tml NOT IN q)) S1).
       * intro Htt. decompose record Htt. clear Htt. exists x0.
-        eexists. split. exact H0. split. constructor. exact Html. exact H1. split.
+        eexists. split. exact H0. split. constructor. apply sem_tml_bool_to_tribool. exact Html. exact H1. split.
         ++ intro. rewrite H2. simpl in H0. pose (s1 := freshlist (length tml)).
            cut (exists Sc, SQLSem2.j_cond_sem d (s1 :: G0)%list
                        (List.fold_right (fun (ta : pretm * Name) acc => let (t, a) := ta in (tmvar (0,a) IS NULL) OR (((tm_lift t 1) IS NULL) OR cndeq (tm_lift t 1) (tmvar (0, a))) AND acc) 
                           (TRUE) (combine tml s1)) Sc).
            intro Hcut. Focus 2. eapply tech_j_cond_fold'.
-           symmetry. apply length_freshlist. apply p_freshlist. exact Html. intro. intuition.
+           symmetry. apply length_freshlist. apply p_freshlist. apply sem_tml_bool_to_tribool. exact Html. intro. intuition.
            decompose record Hcut. 
            assert (Rel.T (length s0) = Rel.T (list_sum (List.map (length (A:=Name)) (freshlist (length tml) :: Datatypes.nil)))).
              symmetry. rewrite <- length_concat_list_sum. simpl. rewrite app_length, length_freshlist.
@@ -1321,7 +1377,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                 rewrite e. reflexivity.
                 apply cast_JMeq. exact H5.
                 symmetry. apply cast_JMeq. reflexivity.
-                exact H3. exact Html. Unshelve.
+                exact H3. apply sem_tml_bool_to_tribool. exact Html. Unshelve.
                 rewrite e; reflexivity.
                 rewrite e; reflexivity.
                 rewrite e; reflexivity.
@@ -1347,7 +1403,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                     rewrite e. reflexivity.
                     symmetry. rewrite <- H5. exact H6.
                     symmetry. apply cast_JMeq. reflexivity.
-                    exact H3. exact Html. Unshelve.
+                    exact H3. apply sem_tml_bool_to_tribool. exact Html. Unshelve.
                     rewrite e; reflexivity.
                     rewrite e; reflexivity.
                     rewrite e; reflexivity.
@@ -1359,7 +1415,7 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
             fold_right2 (fun (r0 V0 : Value) (acc : bool) => (acc && S3.is_btrue (S3.veq r0 V0))%bool) true
             (length s0) rl (cast _ _ (f_equal Rel.T e) (Stml h))))) eqn:e0.
           -- transitivity true. reflexivity. symmetry. apply if_true.
-            ** rewrite <- e0 at 1. rewrite (fold_v_tml_sem1' _ _ _ _ Html h). rewrite H2. reflexivity.
+            ** rewrite <- e0 at 1. rewrite (fold_v_tml_sem1' _ _ _ _ (sem_tml_bool_to_tribool Html) h). rewrite H2. reflexivity.
                apply cast_JMeq. reflexivity.
             ** reflexivity.
           -- transitivity false.
@@ -1368,16 +1424,17 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
                  (acc && negb (S3.is_bfalse (S3.veq r0 V0)))%bool) true (length s0) rl (cast _ _ (f_equal Rel.T e) (Stml h)))));
              reflexivity.
             ** symmetry. apply if_false.
-              +++ rewrite <- e0. rewrite (fold_v_tml_sem1' _ _ _ _ Html h). 
+              +++ rewrite <- e0. rewrite (fold_v_tml_sem1' _ _ _ _ (sem_tml_bool_to_tribool Html) h). 
                   decompose record IHq. destruct (SQLSem2.jq_sem_fun_dep _ _ _ _ _ H4 _ _ _ _ eq_refl eq_refl H1).
                   rewrite H6 in H5. rewrite H5. reflexivity.
                   apply cast_JMeq. reflexivity.
               +++ apply if_elim; reflexivity.
       * destruct (tech_j_cond_fold' d (freshlist (length tml)) (freshlist (length tml)) G0 _ 
-            (eq_sym (length_freshlist _)) (p_freshlist _) _ Html (fun x Hx => Hx)).
-        eexists. constructor. constructor. constructor. constructor. constructor. exact H1.
-        constructor. rewrite length_freshlist. symmetry. exact e. exact H0.
+            (eq_sym (length_freshlist _)) (p_freshlist _) _ (sem_tml_bool_to_tribool Html) (fun x Hx => Hx)).
+        eexists. constructor. constructor. constructor. constructor. constructor. constructor. exact H1.
+        constructor. rewrite length_freshlist. symmetry. exact e. constructor. exact H0.
         Unshelve. simpl. repeat rewrite plus_0_r. rewrite length_freshlist. rewrite e. reflexivity.
+        simpl. rewrite length_freshlist, e. reflexivity.
   + simpl. intros G0 q Sq Hq IHq. decompose record IHq.
     eexists. eexists. 
     split. constructor. exact H1. split. constructor. constructor. exact H1.
@@ -1412,16 +1469,28 @@ Module Translation2V (Db : DB) (Sql : SQL Db).
     eexists. split. constructor. exact H1. exact H3. exact e'.
     intro. apply cast_JMeq. symmetry. apply cast_JMeq.
     rewrite H2, H4. reflexivity.
+  (** mutual induction cases: btbl *)
+  + simpl. intros G0. eexists. split. constructor.
+    intro. reflexivity.
+  + simpl. intros G0 btb btbl G1 G2 Sbtb Sbtbl e Hbtb IHbtb Hbtbl IHbtbl.
+    decompose record IHbtb. decompose record IHbtbl. clear IHbtb IHbtbl.
+    eexists. split. constructor. exact H1. exact H3.
+    intro; simpl. Unshelve.
+    2: { rewrite e'; reflexivity. }
+    2: { rewrite <- length_concat_list_sum, map_app, length_concat_list_sum, list_sum_app. reflexivity. }
+    rewrite H2. apply (f_JMeq _ _ (Rel.rsum (x h))).
+    extensionality Vl. apply JMeq_eq. apply cast_JMeq. symmetry. apply cast_JMeq.
+    rewrite H4. reflexivity.
   (** mutual induction cases: inquery *)
-  + simpl. intros G0 b tml btb c G1 Sbtb Sc Stml Hbtb IHbtb Hc IHc Html.
-    decompose record IHbtb. decompose record IHc.
-    eexists. split. eapply (SQLSem2.jiqs_sel _ _ _ _ _ _ _ _ _ _ H1 H0 Html).
+  + simpl. intros G0 b tml btbl c G1 Sbtbl Sc Stml Hbtbl IHbtbl Hc IHc Html.
+    decompose record IHbtbl. decompose record IHc.
+    eexists. split. eapply (SQLSem2.jiqs_sel _ _ _ _ _ _ _ _ _ _ H1 H0 (sem_tml_bool_to_tribool Html)).
     intro. simpl. destruct b.
     - apply eq_JMeq. f_equal. f_equal. f_equal. apply JMeq_eq. rewrite H2.
       eapply (f_JMequal (Rel.sum _) (Rel.sum _)). Unshelve.
       eapply (f_JMeq _ _ (@Rel.sum _ _)). apply JMeq_eq. eapply (f_JMeq _ _ (Rel.sel _)).
       extensionality Vl. rewrite H4. reflexivity.
-      reflexivity. exact e. reflexivity. reflexivity.
+      reflexivity. reflexivity. reflexivity.
     - apply eq_JMeq. f_equal. f_equal. apply JMeq_eq. rewrite H2.
       eapply (f_JMequal (Rel.sum _) (Rel.sum _)). Unshelve.
       eapply (f_JMeq _ _ (@Rel.sum _ _)). apply JMeq_eq. eapply (f_JMeq _ _ (Rel.sel _)).

--- a/Util.v
+++ b/Util.v
@@ -899,3 +899,17 @@ Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq
     destruct x; intuition. contradiction H. reflexivity.
   Qed.
 
+  Lemma list_sum_O l : (forall x, List.In x l -> x = 0) -> list_sum l = O.
+  Proof.
+    elim l; eauto. intros; simpl. rewrite (H0 a). apply H. 
+    intros; apply H0. right; exact H1. left; reflexivity.
+  Qed.
+
+  Lemma list_sum_O' l : list_sum l = O -> forall x, List.In x l -> x = O.
+  Proof.
+    elim l.
+    simpl; intros; contradiction H0.
+    simpl; intros. destruct (plus_is_O _ _ H0). destruct H1; eauto.
+    rewrite <- H1. exact H2.
+  Qed.
+

--- a/Util.v
+++ b/Util.v
@@ -18,6 +18,11 @@ Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq
     rewrite H. reflexivity.
   Qed.
 
+  Lemma or_eq_lt_n_O n : n = 0 \/ 0 < n.
+  Proof.
+    destruct (Nat.eq_dec n 0); intuition.
+  Qed.
+
   Fixpoint cmap_length {A B : Type} (f : A -> B) l : List.length (List.map f l) = List.length l.
   refine (match l with List.nil => _ | List.cons h t => _ end).
   exact eq_refl.

--- a/Util.v
+++ b/Util.v
@@ -40,8 +40,8 @@ Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq
 
   Lemma length_concat_list_sum (A : Type) (l : list (list A)) : 
     List.length (List.concat l) = list_sum (List.map (@List.length A) l).
-  rewrite <- (map_id l) at 1. rewrite <- flat_map_concat_map.
-  rewrite flat_map_length. apply f_equal. apply map_ext. auto.
+  rewrite <- (List.map_id l) at 1. rewrite <- flat_map_concat_map.
+  rewrite flat_map_length. apply f_equal. apply List.map_ext. auto.
   Defined.
 
   Definition cast (A B : Type) (e : A = B) (a : A) : B.
@@ -325,6 +325,14 @@ Require Import Lists.List Lists.ListSet Vector Arith.PeanoNat Bool.Sumbool JMeq
     length al = length bl -> List.map fst (combine al bl) = al.
   Proof.
     intros. eapply (list_ind2 _ _ (fun al bl => List.map fst (combine al bl) = al) _ _ _ _ H). Unshelve.
+    + reflexivity.
+    + simpl; intros. rewrite H1. reflexivity.
+  Qed.
+
+  Lemma map_snd_combine A B (al : list A) (bl : list B) : 
+    length al = length bl -> List.map snd (combine al bl) = bl.
+  Proof.
+    intros. eapply (list_ind2 _ _ (fun al bl => List.map snd (combine al bl) = bl) _ _ _ _ H). Unshelve.
     + reflexivity.
     + simpl; intros. rewrite H1. reflexivity.
   Qed.


### PR DESCRIPTION
This update adds lateral joins to the SQL formalization.
In addition, it provides a formalization of a version of the Relational Calculus with nulls, and shows that its normal forms can be translated to SQL preserving their semantics.